### PR TITLE
Stop step cards overflowing the viewport on mobile

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -271,7 +271,7 @@ footer a:hover {
 
 .section-subtitle { font-size: 16px; color: var(--text-light); margin-top: -20px; margin-bottom: 32px; }
 .steps-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 20px; }
-.step { background: var(--bg); border-radius: var(--radius); padding: 28px; border: 1px solid var(--border); position: relative; display: flex; flex-direction: column; transition: box-shadow 0.25s, transform 0.25s; }
+.step { background: var(--bg); border-radius: var(--radius); padding: 28px; border: 1px solid var(--border); position: relative; display: flex; flex-direction: column; min-width: 0; transition: box-shadow 0.25s, transform 0.25s; }
 .step:hover { box-shadow: var(--shadow); transform: translateY(-3px); }
 .step-number { position: absolute; top: -14px; left: 24px; width: 32px; height: 32px; border-radius: 50%; background: var(--accent); color: var(--white); display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 15px; box-shadow: 0 2px 8px rgba(232, 91, 114, 0.3); }
 .step h3 { font-size: 18px; font-weight: 700; margin: 8px 0 10px; color: var(--primary); }


### PR DESCRIPTION
The Unity Install via UPM panel embeds an unbreakable URL (https://github.com/ailia-ai/ailia-sdk-unity.git) inside a <pre> block. On narrow mobile widths the grid item that wraps the step kept its default min-width: auto, so it expanded to fit the URL and pushed the whole row past the viewport edge.

Adding min-width: 0 to .step lets the grid item shrink to the column width; the pre block's existing overflow-x: auto then takes over and scrolls within the card instead of distending it.