### PR TITLE
TFLite Python: use yolox.py -v 0 instead of launcher.py

### DIFF
--- a/tflite/index.html
+++ b/tflite/index.html
@@ -82,11 +82,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <div class="step">
             <div class="step-number">2</div>
             <h3>Run a Sample</h3>
-            <p>Clone the ailia-models-tflite repository, install the dependencies, and launch the GUI to pick and run a model.</p>
+            <p>ailia-models-tflite bundles per-model inference scripts. Clone once, install the shared requirements, then <code>cd</code> into any model folder and run — pass <code>-v 0</code> for webcam input or <code>-i image.png</code> for a still. <code>python3 launcher.py</code> at the repo root opens a GUI that browses every quantized TFLite model.</p>
             <pre><code>git clone https://github.com/ailia-ai/ailia-models-tflite.git
 cd ailia-models-tflite
 pip3 install -r requirements.txt
-python3 launcher.py</code></pre>
+cd object_detection/yolox
+python3 yolox.py -v 0</code></pre>
             <a href="https://github.com/ailia-ai/ailia-models-tflite" target="_blank" class="card-link">Sample Repository</a>
           </div>
         </div>


### PR DESCRIPTION
Match the ailia SDK Python tab so both products demonstrate the same direct flow: clone the samples repo, install the shared requirements, cd into a model folder, and run python3 <model>.py -v 0 to feed the webcam through the inference script. The launcher.py GUI is mentioned in the prose for users who prefer to browse the full model catalogue.