### PR TITLE
Update model count from 390+ to 400+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ailia SDK Documentation
 
-The ailia SDK is an inference engine that supports cross-platform operation. ONNX can perform GPU inference using Metal and Vulkan. It offers a model library with over 390 types and supports advanced pre-processing and post-processing. Bindings are provided for Python, C++, C#, and Flutter.
+The ailia SDK is an inference engine that supports cross-platform operation. ONNX can perform GPU inference using Metal and Vulkan. It offers a model library with over 400 types and supports advanced pre-processing and post-processing. Bindings are provided for Python, C++, C#, and Flutter.
 
 **[Full Documentation Site (docs.ailia.ai)](https://docs.ailia.ai)**
 

--- a/index.html
+++ b/index.html
@@ -11,17 +11,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ailia SDK Documentation</title>
-  <meta name="description" content="ailia SDK - Cross-platform inference engine with ONNX GPU inference using Metal and Vulkan. 390+ models, Python/C++/C#/Flutter bindings.">
+  <meta name="description" content="ailia SDK - Cross-platform inference engine with ONNX GPU inference using Metal and Vulkan. 400+ models, Python/C++/C#/Flutter bindings.">
   <link rel="canonical" href="https://docs.ailia.ai/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="ailia SDK Documentation">
   <meta property="og:url" content="https://docs.ailia.ai/">
   <meta property="og:title" content="ailia SDK Documentation">
-  <meta property="og:description" content="ailia SDK - Cross-platform inference engine with ONNX GPU inference using Metal and Vulkan. 390+ models, Python/C++/C#/Flutter bindings.">
+  <meta property="og:description" content="ailia SDK - Cross-platform inference engine with ONNX GPU inference using Metal and Vulkan. 400+ models, Python/C++/C#/Flutter bindings.">
   <meta property="og:image" content="https://docs.ailia.ai/ailia_logo.png">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="ailia SDK Documentation">
-  <meta name="twitter:description" content="ailia SDK - Cross-platform inference engine with ONNX GPU inference using Metal and Vulkan. 390+ models, Python/C++/C#/Flutter bindings.">
+  <meta name="twitter:description" content="ailia SDK - Cross-platform inference engine with ONNX GPU inference using Metal and Vulkan. 400+ models, Python/C++/C#/Flutter bindings.">
   <meta name="twitter:image" content="https://docs.ailia.ai/ailia_logo.png">
   <link rel="icon" type="image/png" href="ailia_logo.png">
   <link rel="stylesheet" href="css/common.css">


### PR DESCRIPTION
The hero badge on the top page already shows "400+ Models" but the meta description, og:description, twitter:description, and the README all still said "390+ models". Bring those in sync with the badge.

- index.html: meta description / og:description / twitter:description now read "400+ models, Python/C++/C#/Flutter bindings."
- README.md: "model library with over 390 types" → "over 400 types".

https://claude.ai/code/session_01JbDFdDmX7a7obg5yEnwkgT