### PR TITLE
Logo: keep text black and align with icon centre line

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -52,7 +52,7 @@ header {
   gap: 12px;
 }
 
-.logo-icon { display: inline-flex; align-items: center; }
+.logo-icon { display: inline-flex; align-items: center; height: 36px; }
 .logo-icon img {
   height: 36px;
   width: auto;
@@ -60,13 +60,17 @@ header {
   display: block;
 }
 
-.logo-text {
+a.logo-text {
+  display: inline-flex;
+  align-items: center;
+  height: 36px;
   font-size: 20px;
   font-weight: 700;
   color: var(--primary);
   letter-spacing: 0.02em;
+  line-height: 1;
 }
-.logo-text:hover { color: var(--accent); }
+a.logo-text:hover { color: var(--accent); }
 
 .header-links {
   display: flex;


### PR DESCRIPTION
Two issues observed on the live mobile screenshot:
- The ailia mark sat slightly above the wordmark's optical centre.
- "ailia X Docs" rendered in the accent (pink) colour instead of the near-black --primary, because the global a { color: var(--accent); } rule was winning despite the .logo-text override.

Bring both children of .logo to a fixed 36px box and centre their contents with line-height: 1, so the icon and text share the same vertical centre. Bump the text selector to a.logo-text (and a.logo-text:hover) so it has a higher specificity than the global anchor rule and reliably keeps the --primary colour.