### PR TITLE
Rename hero / page titles per user request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ailia SDK Documentation
+# ailia Documentation
 
 The ailia SDK is an inference engine that supports cross-platform operation. ONNX can perform GPU inference using Metal and Vulkan. It offers a model library with over 400 types and supports advanced pre-processing and post-processing. Bindings are provided for Python, C++, C#, and Flutter.
 

--- a/api/index.html
+++ b/api/index.html
@@ -10,17 +10,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- End Google Tag Manager -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ailia SDK - Inference Library Documentation</title>
+  <title>ailia SDK</title>
   <meta name="description" content="ailia SDK - ONNX inference API documentation for Python, C++, Unity, Flutter, and JNI.">
   <link rel="canonical" href="https://docs.ailia.ai/api/">
   <meta property="og:type" content="website">
-  <meta property="og:site_name" content="ailia SDK Documentation">
+  <meta property="og:site_name" content="ailia Documentation">
   <meta property="og:url" content="https://docs.ailia.ai/api/">
-  <meta property="og:title" content="ailia SDK - Inference Library Documentation">
+  <meta property="og:title" content="ailia SDK">
   <meta property="og:description" content="ailia SDK - ONNX inference API documentation for Python, C++, Unity, Flutter, and JNI.">
   <meta property="og:image" content="https://docs.ailia.ai/ailia_logo.png">
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="ailia SDK - Inference Library Documentation">
+  <meta name="twitter:title" content="ailia SDK">
   <meta name="twitter:description" content="ailia SDK - ONNX inference API documentation for Python, C++, Unity, Flutter, and JNI.">
   <meta name="twitter:image" content="https://docs.ailia.ai/ailia_logo.png">
   <link rel="icon" type="image/png" href="../ailia_logo.png">
@@ -52,7 +52,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </header>
 
   <section class="hero">
-    <h1>Inference Library Documentation</h1>
+    <h1>ailia SDK</h1>
     <p>This is the ONNX inference API, which serves as the core of everything.</p>
   </section>
 

--- a/api/index.html
+++ b/api/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta name="description" content="ailia SDK - ONNX inference API documentation for Python, C++, Unity, Flutter, and JNI.">
   <link rel="canonical" href="https://docs.ailia.ai/api/">
   <meta property="og:type" content="website">
-  <meta property="og:site_name" content="ailia Documentation">
+  <meta property="og:site_name" content="ailia SDK Documentation">
   <meta property="og:url" content="https://docs.ailia.ai/api/">
   <meta property="og:title" content="ailia SDK Documentation">
   <meta property="og:description" content="ailia SDK - ONNX inference API documentation for Python, C++, Unity, Flutter, and JNI.">

--- a/api/index.html
+++ b/api/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta name="description" content="ailia SDK - ONNX inference API documentation for Python, C++, Unity, Flutter, and JNI.">
   <link rel="canonical" href="https://docs.ailia.ai/api/">
   <meta property="og:type" content="website">
-  <meta property="og:site_name" content="ailia SDK Documentation">
+  <meta property="og:site_name" content="ailia Documentation">
   <meta property="og:url" content="https://docs.ailia.ai/api/">
   <meta property="og:title" content="ailia SDK Documentation">
   <meta property="og:description" content="ailia SDK - ONNX inference API documentation for Python, C++, Unity, Flutter, and JNI.">

--- a/api/index.html
+++ b/api/index.html
@@ -10,17 +10,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- End Google Tag Manager -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ailia SDK</title>
+  <title>ailia SDK Documentation</title>
   <meta name="description" content="ailia SDK - ONNX inference API documentation for Python, C++, Unity, Flutter, and JNI.">
   <link rel="canonical" href="https://docs.ailia.ai/api/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="ailia Documentation">
   <meta property="og:url" content="https://docs.ailia.ai/api/">
-  <meta property="og:title" content="ailia SDK">
+  <meta property="og:title" content="ailia SDK Documentation">
   <meta property="og:description" content="ailia SDK - ONNX inference API documentation for Python, C++, Unity, Flutter, and JNI.">
   <meta property="og:image" content="https://docs.ailia.ai/ailia_logo.png">
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="ailia SDK">
+  <meta name="twitter:title" content="ailia SDK Documentation">
   <meta name="twitter:description" content="ailia SDK - ONNX inference API documentation for Python, C++, Unity, Flutter, and JNI.">
   <meta name="twitter:image" content="https://docs.ailia.ai/ailia_logo.png">
   <link rel="icon" type="image/png" href="../ailia_logo.png">
@@ -52,7 +52,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </header>
 
   <section class="hero">
-    <h1>ailia SDK</h1>
+    <h1>ailia SDK Documentation</h1>
     <p>This is the ONNX inference API, which serves as the core of everything.</p>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -10,17 +10,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- End Google Tag Manager -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ailia SDK Documentation</title>
+  <title>ailia Documentation</title>
   <meta name="description" content="ailia SDK - Cross-platform inference engine with ONNX GPU inference using Metal and Vulkan. 400+ models, Python/C++/C#/Flutter bindings.">
   <link rel="canonical" href="https://docs.ailia.ai/">
   <meta property="og:type" content="website">
-  <meta property="og:site_name" content="ailia SDK Documentation">
+  <meta property="og:site_name" content="ailia Documentation">
   <meta property="og:url" content="https://docs.ailia.ai/">
-  <meta property="og:title" content="ailia SDK Documentation">
+  <meta property="og:title" content="ailia Documentation">
   <meta property="og:description" content="ailia SDK - Cross-platform inference engine with ONNX GPU inference using Metal and Vulkan. 400+ models, Python/C++/C#/Flutter bindings.">
   <meta property="og:image" content="https://docs.ailia.ai/ailia_logo.png">
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="ailia SDK Documentation">
+  <meta name="twitter:title" content="ailia Documentation">
   <meta name="twitter:description" content="ailia SDK - Cross-platform inference engine with ONNX GPU inference using Metal and Vulkan. 400+ models, Python/C++/C#/Flutter bindings.">
   <meta name="twitter:image" content="https://docs.ailia.ai/ailia_logo.png">
   <link rel="icon" type="image/png" href="ailia_logo.png">
@@ -92,7 +92,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
   <!-- Hero -->
   <section class="hero">
-    <h1>ailia SDK Documentation</h1>
+    <h1>ailia Documentation</h1>
     <p>Cross-platform inference engine supporting GPU inference via Metal and Vulkan. A model library with over 400 types, advanced pre/post-processing, and bindings for Python, C++, C#, and Flutter.</p>
     <div class="hero-badges">
       <span class="badge">

--- a/llm/index.html
+++ b/llm/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta name="description" content="ailia LLM - Library for running local LLMs with GGUF support.">
   <link rel="canonical" href="https://docs.ailia.ai/llm/">
   <meta property="og:type" content="website">
-  <meta property="og:site_name" content="ailia SDK Documentation">
+  <meta property="og:site_name" content="ailia Documentation">
   <meta property="og:url" content="https://docs.ailia.ai/llm/">
   <meta property="og:title" content="ailia LLM - Documentation">
   <meta property="og:description" content="ailia LLM - Library for running local LLMs with GGUF support.">

--- a/speech/index.html
+++ b/speech/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta name="description" content="ailia Speech - Speech recognition library for Speech-to-Text conversion.">
   <link rel="canonical" href="https://docs.ailia.ai/speech/">
   <meta property="og:type" content="website">
-  <meta property="og:site_name" content="ailia SDK Documentation">
+  <meta property="og:site_name" content="ailia Documentation">
   <meta property="og:url" content="https://docs.ailia.ai/speech/">
   <meta property="og:title" content="ailia Speech - Documentation">
   <meta property="og:description" content="ailia Speech - Speech recognition library for Speech-to-Text conversion.">

--- a/tflite/index.html
+++ b/tflite/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta name="description" content="ailia TFLite Runtime - AI inference engine for embedded devices such as NonOS and RTOS.">
   <link rel="canonical" href="https://docs.ailia.ai/tflite/">
   <meta property="og:type" content="website">
-  <meta property="og:site_name" content="ailia SDK Documentation">
+  <meta property="og:site_name" content="ailia Documentation">
   <meta property="og:url" content="https://docs.ailia.ai/tflite/">
   <meta property="og:title" content="ailia TFLite Runtime - Documentation">
   <meta property="og:description" content="ailia TFLite Runtime - AI inference engine for embedded devices such as NonOS and RTOS.">

--- a/tokenizer/index.html
+++ b/tokenizer/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta name="description" content="ailia Tokenizer - Tokenization library for NLP text encoding and decoding.">
   <link rel="canonical" href="https://docs.ailia.ai/tokenizer/">
   <meta property="og:type" content="website">
-  <meta property="og:site_name" content="ailia SDK Documentation">
+  <meta property="og:site_name" content="ailia Documentation">
   <meta property="og:url" content="https://docs.ailia.ai/tokenizer/">
   <meta property="og:title" content="ailia Tokenizer - Documentation">
   <meta property="og:description" content="ailia Tokenizer - Tokenization library for NLP text encoding and decoding.">

--- a/tracker/index.html
+++ b/tracker/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta name="description" content="ailia Tracker - Object movement tracking for real-time video analysis.">
   <link rel="canonical" href="https://docs.ailia.ai/tracker/">
   <meta property="og:type" content="website">
-  <meta property="og:site_name" content="ailia SDK Documentation">
+  <meta property="og:site_name" content="ailia Documentation">
   <meta property="og:url" content="https://docs.ailia.ai/tracker/">
   <meta property="og:title" content="ailia Tracker - Documentation">
   <meta property="og:description" content="ailia Tracker - Object movement tracking for real-time video analysis.">

--- a/voice/index.html
+++ b/voice/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta name="description" content="ailia Voice - Text-to-speech synthesis library for natural voice generation.">
   <link rel="canonical" href="https://docs.ailia.ai/voice/">
   <meta property="og:type" content="website">
-  <meta property="og:site_name" content="ailia SDK Documentation">
+  <meta property="og:site_name" content="ailia Documentation">
   <meta property="og:url" content="https://docs.ailia.ai/voice/">
   <meta property="og:title" content="ailia Voice - Documentation">
   <meta property="og:description" content="ailia Voice - Text-to-speech synthesis library for natural voice generation.">


### PR DESCRIPTION
- api/index.html
  - <title>: "ailia SDK - Inference Library Documentation" → "ailia SDK"
  - og:title / twitter:title: same rename
  - hero <h1>: "Inference Library Documentation" → "ailia SDK"

- index.html (top)
  - <title>: "ailia SDK Documentation" → "ailia Documentation"
  - og:title / twitter:title: same rename
  - hero <h1>: "ailia SDK Documentation" → "ailia Documentation"

- og:site_name on every page (top + 7 sub-pages): "ailia SDK Documentation" → "ailia Documentation"

- README.md heading: "ailia SDK Documentation" → "ailia Documentation"