### PR TITLE
api hero: drop "Documentation" suffix from <h1>

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -52,7 +52,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </header>
 
   <section class="hero">
-    <h1>ailia SDK Documentation</h1>
+    <h1>ailia SDK</h1>
     <p>This is the ONNX inference API, which serves as the core of everything.</p>
   </section>
 


### PR DESCRIPTION
Match the other sub-page heroes which use the bare product name: ailia Speech / ailia Voice / ailia LLM / ailia TFLite Runtime / ailia Tokenizer / ailia Tracker. Update the api page to <h1>ailia SDK</h1> for the same convention. The <title>, og:title, and twitter:title keep "ailia SDK Documentation" since those identify the page in browser chrome and social previews.