### PR TITLE
Header nav: rename ONNX → SDK

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -39,7 +39,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </button>
       <div class="header-links">
         <a href="../">Top</a>
-        <a href="../api/">ONNX</a>
+        <a href="../api/">SDK</a>
         <a href="../tflite/">TFLite</a>
         <a href="../llm/">LLM</a>
         <a href="../speech/">Speech</a>

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
       </button>
       <div class="header-links">
-        <a href="api/">ONNX</a>
+        <a href="api/">SDK</a>
         <a href="tflite/">TFLite</a>
         <a href="llm/">LLM</a>
         <a href="speech/">Speech</a>

--- a/llm/index.html
+++ b/llm/index.html
@@ -39,7 +39,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </button>
       <div class="header-links">
         <a href="../">Top</a>
-        <a href="../api/">ONNX</a>
+        <a href="../api/">SDK</a>
         <a href="../tflite/">TFLite</a>
         <a href="../llm/">LLM</a>
         <a href="../speech/">Speech</a>

--- a/speech/index.html
+++ b/speech/index.html
@@ -39,7 +39,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </button>
       <div class="header-links">
         <a href="../">Top</a>
-        <a href="../api/">ONNX</a>
+        <a href="../api/">SDK</a>
         <a href="../tflite/">TFLite</a>
         <a href="../llm/">LLM</a>
         <a href="../speech/">Speech</a>

--- a/tflite/index.html
+++ b/tflite/index.html
@@ -39,7 +39,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </button>
       <div class="header-links">
         <a href="../">Top</a>
-        <a href="../api/">ONNX</a>
+        <a href="../api/">SDK</a>
         <a href="../tflite/">TFLite</a>
         <a href="../llm/">LLM</a>
         <a href="../speech/">Speech</a>

--- a/tokenizer/index.html
+++ b/tokenizer/index.html
@@ -39,7 +39,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </button>
       <div class="header-links">
         <a href="../">Top</a>
-        <a href="../api/">ONNX</a>
+        <a href="../api/">SDK</a>
         <a href="../tflite/">TFLite</a>
         <a href="../llm/">LLM</a>
         <a href="../speech/">Speech</a>

--- a/tracker/index.html
+++ b/tracker/index.html
@@ -39,7 +39,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </button>
       <div class="header-links">
         <a href="../">Top</a>
-        <a href="../api/">ONNX</a>
+        <a href="../api/">SDK</a>
         <a href="../tflite/">TFLite</a>
         <a href="../llm/">LLM</a>
         <a href="../speech/">Speech</a>

--- a/voice/index.html
+++ b/voice/index.html
@@ -39,7 +39,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </button>
       <div class="header-links">
         <a href="../">Top</a>
-        <a href="../api/">ONNX</a>
+        <a href="../api/">SDK</a>
         <a href="../tflite/">TFLite</a>
         <a href="../llm/">LLM</a>
         <a href="../speech/">Speech</a>


### PR DESCRIPTION
The /api/ page now reads "ailia SDK" in its hero, so the nav link should match. Update the header link label across every page (top
+ seven sub-pages) from "ONNX" to "SDK". The href stays at api/ since that is where the page lives. ONNX as the model format is still referenced in body prose and badges.