### PR TITLE
api: page title now "ailia SDK - Documentation" (with hyphen)

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -10,17 +10,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- End Google Tag Manager -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ailia SDK Documentation</title>
+  <title>ailia SDK - Documentation</title>
   <meta name="description" content="ailia SDK - ONNX inference API documentation for Python, C++, Unity, Flutter, and JNI.">
   <link rel="canonical" href="https://docs.ailia.ai/api/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="ailia Documentation">
   <meta property="og:url" content="https://docs.ailia.ai/api/">
-  <meta property="og:title" content="ailia SDK Documentation">
+  <meta property="og:title" content="ailia SDK - Documentation">
   <meta property="og:description" content="ailia SDK - ONNX inference API documentation for Python, C++, Unity, Flutter, and JNI.">
   <meta property="og:image" content="https://docs.ailia.ai/ailia_logo.png">
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="ailia SDK Documentation">
+  <meta name="twitter:title" content="ailia SDK - Documentation">
   <meta name="twitter:description" content="ailia SDK - ONNX inference API documentation for Python, C++, Unity, Flutter, and JNI.">
   <meta name="twitter:image" content="https://docs.ailia.ai/ailia_logo.png">
   <link rel="icon" type="image/png" href="../ailia_logo.png">


### PR DESCRIPTION
Match the title pattern used by every other sub-page — "ailia Speech - Documentation", "ailia LLM - Documentation", "ailia TFLite Runtime - Documentation", and so on. The api page read "ailia SDK Documentation" without the separator, which stood out. Add the hyphen so <title>, og:title and twitter:title all read "ailia SDK - Documentation" consistently.