### PR TITLE
SDK FAQ: explain AILIAShape's x/y/z/w mapping

### DIFF
--- a/en/sdk/index.html
+++ b/en/sdk/index.html
@@ -477,6 +477,20 @@ println(output.size)</code></pre>
       </details>
 
       <details class="faq-item">
+        <summary>What do <code>AILIAShape</code>'s x / y / z / w correspond to?</summary>
+        <p><code>AILIAShape</code> represents up to 4 dimensions through <code>x</code> / <code>y</code> / <code>z</code> / <code>w</code> + <code>dim</code>. <strong><code>x</code> is the innermost (memory-contiguous) axis and <code>w</code> is the outermost.</strong> For a numpy-style <code>(batch, channel, height, width)</code> 4-D tensor, that maps to <code>w = batch</code>, <code>z = channel</code>, <code>y = height</code>, <code>x = width</code>.</p>
+        <p>The <code>dim</code> field tells you how many of those axes are valid:</p>
+        <ul>
+          <li><code>dim = 0</code>: scalar (ONNX rank-0 tensor)</li>
+          <li><code>dim = 1</code>: <code>x</code> only</li>
+          <li><code>dim = 2</code>: <code>x</code> and <code>y</code></li>
+          <li><code>dim = 3</code>: <code>x</code> / <code>y</code> / <code>z</code></li>
+          <li><code>dim = 4</code>: <code>x</code> / <code>y</code> / <code>z</code> / <code>w</code></li>
+        </ul>
+        <p>Tensors with rank ≥ 5 cannot be expressed in <code>AILIAShape</code>. Use the ND variants instead — <code>ailiaSetInputShapeND</code> / <code>ailiaGetOutputShapeND</code> (with <code>ailiaGetInputDim</code> / <code>ailiaGetOutputDim</code>) — which take a flat <code>unsigned int*</code> shape array.</p>
+      </details>
+
+      <details class="faq-item">
         <summary>How do I profile inference performance?</summary>
         <p>A built-in profiler reports per-layer timing.</p>
         <p><strong>Python:</strong> call <code>net.set_profile_mode(True)</code>, run inference, and read the per-layer summary with <code>net.get_summary()</code>.</p>

--- a/sdk/index.html
+++ b/sdk/index.html
@@ -477,6 +477,20 @@ println(output.size)</code></pre>
       </details>
 
       <details class="faq-item">
+        <summary><code>AILIAShape</code> の x / y / z / w は何に対応しますか?</summary>
+        <p><code>AILIAShape</code> は最大 4 次元までを <code>x</code> / <code>y</code> / <code>z</code> / <code>w</code> + <code>dim</code> で表します。<strong><code>x</code> が最も内側 (innermost、メモリ連続側) の軸、<code>w</code> が最も外側 (outermost) の軸</strong>です。たとえば numpy で <code>(batch, channel, height, width)</code> の 4 次元テンソルなら <code>w = batch</code>、<code>z = channel</code>、<code>y = height</code>、<code>x = width</code> が対応します。</p>
+        <p>有効な軸数は <code>dim</code> フィールドが示します:</p>
+        <ul>
+          <li><code>dim = 0</code>: スカラー (ONNX の rank-0 テンソル)</li>
+          <li><code>dim = 1</code>: <code>x</code> のみ</li>
+          <li><code>dim = 2</code>: <code>x</code> と <code>y</code></li>
+          <li><code>dim = 3</code>: <code>x</code> / <code>y</code> / <code>z</code></li>
+          <li><code>dim = 4</code>: <code>x</code> / <code>y</code> / <code>z</code> / <code>w</code></li>
+        </ul>
+        <p>5 次元以上のテンソルは <code>AILIAShape</code> では表現できないため、<code>ailiaSetInputShapeND</code> / <code>ailiaGetOutputShapeND</code> (および <code>ailiaGetInputDim</code> / <code>ailiaGetOutputDim</code>) で <code>unsigned int*</code> 配列として直接形状を扱ってください。</p>
+      </details>
+
+      <details class="faq-item">
         <summary>パフォーマンスを分析するには?</summary>
         <p>レイヤーごとの処理時間を見られるプロファイラを内蔵しています。</p>
         <p><strong>Python:</strong> <code>net.set_profile_mode(True)</code> でプロファイルを有効化してから推論し、<code>net.get_summary()</code> でレイヤー単位の処理時間サマリを取得します。</p>


### PR DESCRIPTION
The doxygen for AILIAShape only says "Size along the X / Y / Z / W axis" without telling readers how those map onto a numpy-style shape. Document the convention explicitly: x is the innermost (memory-contiguous) axis, w is the outermost, so (batch, channel, height, width) becomes (w, z, y, x). Spell out what each dim value selects, that dim=0 is the ONNX scalar case, and that rank ≥ 5 tensors must use the *ShapeND APIs (verified via the bundled doxygen — ailiaSetInputShapeND / ailiaGetOutputShapeND / ailiaGetInputDim / ailiaGetOutputDim).