### PR TITLE
SDK FAQ: explain AILIA_STATUS_UNSETTLED_SHAPE for dynamic-shape models

### DIFF
--- a/en/sdk/index.html
+++ b/en/sdk/index.html
@@ -491,6 +491,13 @@ println(output.size)</code></pre>
       </details>
 
       <details class="faq-item">
+        <summary>I'm hitting <code>AILIA_STATUS_UNSETTLED_SHAPE</code></summary>
+        <p>When the ONNX was exported with dynamic shape, the engine can't resolve the shape until you tell it the actual input dimensions. Calling inference or <code>ailiaGetOutputShape</code> before <code>ailiaSetInputShape</code> (or <code>ailiaSetInputShapeND</code> for rank ≥ 5) returns <code>AILIA_STATUS_UNSETTLED_SHAPE</code> (-18).</p>
+        <p><strong>Python:</strong> <code>net.run()</code> inspects the input array's shape and calls <code>ailiaSetInputShape</code> for you, so no extra step is needed.</p>
+        <p><strong>C / C# (Unity) / Kotlin (JNI) / Dart (Flutter):</strong> set the input shape explicitly via the equivalent <code>ailiaSetInputShape</code> call before running inference.</p>
+      </details>
+
+      <details class="faq-item">
         <summary>How do I profile inference performance?</summary>
         <p>A built-in profiler reports per-layer timing.</p>
         <p><strong>Python:</strong> call <code>net.set_profile_mode(True)</code>, run inference, and read the per-layer summary with <code>net.get_summary()</code>.</p>

--- a/sdk/index.html
+++ b/sdk/index.html
@@ -491,6 +491,13 @@ println(output.size)</code></pre>
       </details>
 
       <details class="faq-item">
+        <summary><code>AILIA_STATUS_UNSETTLED_SHAPE</code> が発生します</summary>
+        <p>dynamic shape (動的形状) でエクスポートされた ONNX モデルでは、入力形状を確定するまでエンジンは shape を解決できません。<code>ailiaSetInputShape</code> (5 次元以上は <code>ailiaSetInputShapeND</code>) を呼び出さずに推論や <code>ailiaGetOutputShape</code> を実行すると <code>AILIA_STATUS_UNSETTLED_SHAPE</code> (-18) が返ります。</p>
+        <p><strong>Python:</strong> <code>net.run()</code> 内部で入力配列の shape から自動的に <code>ailiaSetInputShape</code> を呼び出すため、利用者の追加対応は不要です。</p>
+        <p><strong>C / C# (Unity) / Kotlin (JNI) / Dart (Flutter):</strong> 推論前に明示的に <code>ailiaSetInputShape</code> (相当の API) を呼び出して形状を確定させてください。</p>
+      </details>
+
+      <details class="faq-item">
         <summary>パフォーマンスを分析するには?</summary>
         <p>レイヤーごとの処理時間を見られるプロファイラを内蔵しています。</p>
         <p><strong>Python:</strong> <code>net.set_profile_mode(True)</code> でプロファイルを有効化してから推論し、<code>net.get_summary()</code> でレイヤー単位の処理時間サマリを取得します。</p>


### PR DESCRIPTION
Document the (-18) return code: dynamic-shape ONNX models need an explicit ailiaSetInputShape (or ailiaSetInputShapeND for rank ≥ 5) before inference or ailiaGetOutputShape, otherwise the engine has no way to resolve shapes. Python's net.run() autocalls SetInputShape from the input array's shape; C / C# (Unity) / Kotlin (JNI) / Dart (Flutter) wrappers expose the call directly and require it. Added the entry right after the AILIAShape mapping FAQ since both are about shape handling. Verified the macro and message via the bundled doxygen output.