### PR TITLE
SDK FAQ: drop <code> from titles, style <ul> bullets inside .faq-item

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -403,6 +403,8 @@ code { overflow-wrap: anywhere; }
 .faq-item[open] summary::before { content: "\2212"; }
 .faq-item p { margin-top: 14px; color: var(--text-light); font-size: 14px; line-height: 1.7; }
 .faq-item p + p { margin-top: 10px; }
+.faq-item ul { margin: 10px 0 0; padding-left: 22px; color: var(--text-light); font-size: 14px; line-height: 1.7; }
+.faq-item ul li { margin-bottom: 4px; }
 .faq-item code { background: var(--bg); padding: 2px 6px; border-radius: 4px; font-size: 13px; }
 
 /* Guide / Article */

--- a/en/sdk/index.html
+++ b/en/sdk/index.html
@@ -477,7 +477,7 @@ println(output.size)</code></pre>
       </details>
 
       <details class="faq-item">
-        <summary>What do <code>AILIAShape</code>'s x / y / z / w correspond to?</summary>
+        <summary>What do AILIAShape's x / y / z / w correspond to?</summary>
         <p><code>AILIAShape</code> represents up to 4 dimensions through <code>x</code> / <code>y</code> / <code>z</code> / <code>w</code> + <code>dim</code>. <strong><code>x</code> is the innermost (memory-contiguous) axis and <code>w</code> is the outermost.</strong> For a numpy-style <code>(batch, channel, height, width)</code> 4-D tensor, that maps to <code>w = batch</code>, <code>z = channel</code>, <code>y = height</code>, <code>x = width</code>.</p>
         <p>The <code>dim</code> field tells you how many of those axes are valid:</p>
         <ul>
@@ -491,7 +491,7 @@ println(output.size)</code></pre>
       </details>
 
       <details class="faq-item">
-        <summary>I'm hitting <code>AILIA_STATUS_UNSETTLED_SHAPE</code></summary>
+        <summary>I'm hitting AILIA_STATUS_UNSETTLED_SHAPE</summary>
         <p>When the ONNX was exported with dynamic shape, the engine can't resolve the shape until you tell it the actual input dimensions. Calling inference or <code>ailiaGetOutputShape</code> before <code>ailiaSetInputShape</code> (or <code>ailiaSetInputShapeND</code> for rank ≥ 5) returns <code>AILIA_STATUS_UNSETTLED_SHAPE</code> (-18).</p>
         <p><strong>Python:</strong> <code>net.run()</code> inspects the input array's shape and calls <code>ailiaSetInputShape</code> for you, so no extra step is needed.</p>
         <p><strong>C / C# (Unity) / Kotlin (JNI) / Dart (Flutter):</strong> set the input shape explicitly via the equivalent <code>ailiaSetInputShape</code> call before running inference.</p>

--- a/sdk/index.html
+++ b/sdk/index.html
@@ -477,7 +477,7 @@ println(output.size)</code></pre>
       </details>
 
       <details class="faq-item">
-        <summary><code>AILIAShape</code> の x / y / z / w は何に対応しますか?</summary>
+        <summary>AILIAShape の x / y / z / w は何に対応しますか?</summary>
         <p><code>AILIAShape</code> は最大 4 次元までを <code>x</code> / <code>y</code> / <code>z</code> / <code>w</code> + <code>dim</code> で表します。<strong><code>x</code> が最も内側 (innermost、メモリ連続側) の軸、<code>w</code> が最も外側 (outermost) の軸</strong>です。たとえば numpy で <code>(batch, channel, height, width)</code> の 4 次元テンソルなら <code>w = batch</code>、<code>z = channel</code>、<code>y = height</code>、<code>x = width</code> が対応します。</p>
         <p>有効な軸数は <code>dim</code> フィールドが示します:</p>
         <ul>
@@ -491,7 +491,7 @@ println(output.size)</code></pre>
       </details>
 
       <details class="faq-item">
-        <summary><code>AILIA_STATUS_UNSETTLED_SHAPE</code> が発生します</summary>
+        <summary>AILIA_STATUS_UNSETTLED_SHAPE が発生します</summary>
         <p>dynamic shape (動的形状) でエクスポートされた ONNX モデルでは、入力形状を確定するまでエンジンは shape を解決できません。<code>ailiaSetInputShape</code> (5 次元以上は <code>ailiaSetInputShapeND</code>) を呼び出さずに推論や <code>ailiaGetOutputShape</code> を実行すると <code>AILIA_STATUS_UNSETTLED_SHAPE</code> (-18) が返ります。</p>
         <p><strong>Python:</strong> <code>net.run()</code> 内部で入力配列の shape から自動的に <code>ailiaSetInputShape</code> を呼び出すため、利用者の追加対応は不要です。</p>
         <p><strong>C / C# (Unity) / Kotlin (JNI) / Dart (Flutter):</strong> 推論前に明示的に <code>ailiaSetInputShape</code> (相当の API) を呼び出して形状を確定させてください。</p>


### PR DESCRIPTION
- The FAQ summary uses display:flex with gap:14px, so an inline <code> in the title rendered with extra horizontal padding and threw the line height off. Strip <code> from the AILIAShape and AILIA_STATUS_UNSETTLED_SHAPE summaries (JA + EN).
- Add CSS rules for .faq-item ul and .faq-item li so bullet lists match the surrounding <p> typography (light gray, 14px, 1.7 line-height) and have the standard 22px indent. Without this, the AILIAShape FAQ's "dim = 0..4" list rendered flush with the FAQ card edge.