### PR TITLE
Add a Copy button to every code block

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -389,6 +389,11 @@ footer a:hover {
 .code-block { background: var(--white); color: var(--text); padding: 22px 24px; border: 1px solid var(--border); border-radius: var(--radius); font-size: 14px; line-height: 1.7; overflow-x: auto; font-family: "SFMono-Regular", Menlo, Consolas, monospace; }
 .code-block code { background: transparent; color: inherit; font-family: inherit; padding: 0; }
 
+pre.has-copy-btn { position: relative; }
+.code-copy-btn { position: absolute; top: 8px; right: 8px; padding: 4px 10px; font-size: 12px; font-family: inherit; background: var(--white); color: var(--text-light); border: 1px solid var(--border); border-radius: 4px; cursor: pointer; transition: color 0.15s, border-color 0.15s, background 0.15s; z-index: 2; }
+.code-copy-btn:hover { color: var(--accent); border-color: var(--accent); }
+.code-copy-btn.copied { color: #16a34a; border-color: #16a34a; }
+
 /* Inline <code> in prose can wrap on long unbreakable strings (e.g. paths).
    <pre><code> blocks are unaffected because <pre> sets white-space: pre. */
 code { overflow-wrap: anywhere; }

--- a/css/common.css
+++ b/css/common.css
@@ -365,7 +365,7 @@ footer a:hover {
 .section-subtitle { font-size: 16px; color: var(--text-light); margin-top: -20px; margin-bottom: 32px; }
 .steps-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 20px; }
 .step { background: var(--bg); border-radius: var(--radius); padding: 28px; border: 1px solid var(--border); position: relative; display: flex; flex-direction: column; min-width: 0; transition: box-shadow 0.25s, transform 0.25s; }
-.step:hover { box-shadow: var(--shadow); transform: translateY(-3px); }
+.step:hover { box-shadow: var(--shadow); }
 .step-number { position: absolute; top: -14px; left: 24px; width: 32px; height: 32px; border-radius: 50%; background: var(--accent); color: var(--white); display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 15px; box-shadow: 0 2px 8px rgba(232, 91, 114, 0.3); }
 .step h3 { font-size: 18px; font-weight: 700; margin: 8px 0 10px; color: var(--primary); }
 .step p { font-size: 14px; color: var(--text-light); margin-bottom: 14px; line-height: 1.7; }
@@ -390,9 +390,11 @@ footer a:hover {
 .code-block code { background: transparent; color: inherit; font-family: inherit; padding: 0; }
 
 pre.has-copy-btn { position: relative; }
-.code-copy-btn { position: absolute; top: 8px; right: 8px; padding: 4px 10px; font-size: 12px; font-family: inherit; background: var(--white); color: var(--text-light); border: 1px solid var(--border); border-radius: 4px; cursor: pointer; transition: color 0.15s, border-color 0.15s, background 0.15s; z-index: 2; }
+.code-copy-btn { position: absolute; top: 8px; right: 8px; width: 28px; height: 28px; padding: 0; display: inline-flex; align-items: center; justify-content: center; background: transparent; color: var(--text-light); border: 1px solid transparent; border-radius: 6px; cursor: pointer; transition: color 0.15s, background 0.15s, border-color 0.15s; z-index: 2; }
+.code-copy-btn svg { width: 16px; height: 16px; display: block; }
+pre.has-copy-btn:hover .code-copy-btn { border-color: var(--border); background: var(--white); }
 .code-copy-btn:hover { color: var(--accent); border-color: var(--accent); }
-.code-copy-btn.copied { color: #16a34a; border-color: #16a34a; }
+.code-copy-btn.copied { color: #16a34a; border-color: #16a34a; background: var(--white); }
 
 /* Inline <code> in prose can wrap on long unbreakable strings (e.g. paths).
    <pre><code> blocks are unaffected because <pre> sets white-space: pre. */

--- a/en/index.html
+++ b/en/index.html
@@ -288,5 +288,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       });
     });
   </script>
+  <script src="../js/copy.js" defer></script>
 </body>
 </html>

--- a/en/llm/index.html
+++ b/en/llm/index.html
@@ -509,5 +509,6 @@ while (!done) {
       });
     });
   </script>
+  <script src="../../js/copy.js" defer></script>
 </body>
 </html>

--- a/en/sdk/index.html
+++ b/en/sdk/index.html
@@ -109,10 +109,9 @@ python3 yolox.py -v 0</code></pre>
             <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-models-cpp.git
 cd ailia-models-cpp
 git submodule init
-git submodule update
-
-# macOS: clear the quarantine attribute on bundled dylibs
-./xattr.sh</code></pre>
+git submodule update</code></pre>
+            <p>On macOS only, clear the quarantine attribute on the bundled dylibs:</p>
+            <pre><code class="language-bash">./xattr.sh</code></pre>
             <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">Sample Repository</a>
             <a href="https://github.com/ailia-ai/ailia-sdk-cpp" target="_blank" class="card-link">Binding</a>
           </div>

--- a/en/sdk/index.html
+++ b/en/sdk/index.html
@@ -644,5 +644,6 @@ net.set_memory_mode(memory_mode)</code></pre>
       });
     });
   </script>
+  <script src="../../js/copy.js" defer></script>
 </body>
 </html>

--- a/en/speech/index.html
+++ b/en/speech/index.html
@@ -107,10 +107,9 @@ python3 example_ailia_speech.py</code></pre>
             <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-models-cpp.git
 cd ailia-models-cpp
 git submodule init
-git submodule update
-
-# macOS: clear the quarantine attribute on bundled dylibs
-./xattr.sh</code></pre>
+git submodule update</code></pre>
+            <p>On macOS only, clear the quarantine attribute on the bundled dylibs:</p>
+            <pre><code class="language-bash">./xattr.sh</code></pre>
             <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">Sample Repository</a>
             <a href="https://github.com/ailia-ai/ailia-models-cpp/blob/master/audio_processing/whisper/whisper.cpp" target="_blank" class="card-link">whisper.cpp sample</a>
           </div>

--- a/en/speech/index.html
+++ b/en/speech/index.html
@@ -720,5 +720,6 @@ speech.close()</code></pre>
       });
     });
   </script>
+  <script src="../../js/copy.js" defer></script>
 </body>
 </html>

--- a/en/tflite/index.html
+++ b/en/tflite/index.html
@@ -108,10 +108,9 @@ python3 yolox.py -v 0</code></pre>
             <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-models-cpp.git
 cd ailia-models-cpp
 git submodule init
-git submodule update
-
-# macOS: clear the quarantine attribute on bundled dylibs
-./xattr.sh</code></pre>
+git submodule update</code></pre>
+            <p>On macOS only, clear the quarantine attribute on the bundled dylibs:</p>
+            <pre><code class="language-bash">./xattr.sh</code></pre>
             <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">Sample Repository</a>
             <a href="https://github.com/ailia-ai/ailia-models-cpp/tree/master/object_detection/yolox_tflite" target="_blank" class="card-link">yolox_tflite sample</a>
           </div>

--- a/en/tflite/index.html
+++ b/en/tflite/index.html
@@ -524,5 +524,6 @@ tflite.close()</code></pre>
       });
     });
   </script>
+  <script src="../../js/copy.js" defer></script>
 </body>
 </html>

--- a/en/tokenizer/index.html
+++ b/en/tokenizer/index.html
@@ -533,5 +533,6 @@ val text = tokenizer.decode(ids)</code></pre>
       });
     });
   </script>
+  <script src="../../js/copy.js" defer></script>
 </body>
 </html>

--- a/en/tracker/index.html
+++ b/en/tracker/index.html
@@ -485,5 +485,6 @@ tracker.close()</code></pre>
       });
     });
   </script>
+  <script src="../../js/copy.js" defer></script>
 </body>
 </html>

--- a/en/tracker/index.html
+++ b/en/tracker/index.html
@@ -83,10 +83,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-models-cpp.git
 cd ailia-models-cpp
 git submodule init
-git submodule update
-
-# macOS: clear the quarantine attribute on bundled dylibs
-./xattr.sh</code></pre>
+git submodule update</code></pre>
+            <p>On macOS only, clear the quarantine attribute on the bundled dylibs:</p>
+            <pre><code class="language-bash">./xattr.sh</code></pre>
             <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">Sample Repository</a>
             <a href="https://github.com/ailia-ai/ailia-models-cpp/tree/master/object_tracking/bytetrack" target="_blank" class="card-link">bytetrack sample</a>
           </div>

--- a/en/voice/index.html
+++ b/en/voice/index.html
@@ -647,5 +647,6 @@ pyopenjtalk.mecab_dict_index("userdic.csv", "userdic.dic")</code></pre>
       });
     });
   </script>
+  <script src="../../js/copy.js" defer></script>
 </body>
 </html>

--- a/en/voice/index.html
+++ b/en/voice/index.html
@@ -106,10 +106,9 @@ python3 example_ailia_voice.py</code></pre>
             <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-models-cpp.git
 cd ailia-models-cpp
 git submodule init
-git submodule update
-
-# macOS: clear the quarantine attribute on bundled dylibs
-./xattr.sh</code></pre>
+git submodule update</code></pre>
+            <p>On macOS only, clear the quarantine attribute on the bundled dylibs:</p>
+            <pre><code class="language-bash">./xattr.sh</code></pre>
             <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">Sample Repository</a>
             <a href="https://github.com/ailia-ai/ailia-models-cpp/tree/master/audio_processing/gpt-sovits-v2-pro" target="_blank" class="card-link">gpt-sovits-v2-pro sample</a>
           </div>

--- a/index.html
+++ b/index.html
@@ -288,5 +288,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       });
     });
   </script>
+  <script src="js/copy.js" defer></script>
 </body>
 </html>

--- a/js/copy.js
+++ b/js/copy.js
@@ -1,8 +1,8 @@
 // Adds a "Copy" button to every <pre><code> block on the page.
 // Idempotent: the button is only added once per <pre>.
 (function () {
-  const LABEL = "Copy";
-  const COPIED = "Copied";
+  const COPY_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+  const CHECK_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>';
 
   function attach(pre) {
     if (pre.querySelector(':scope > .code-copy-btn')) return;
@@ -14,8 +14,9 @@
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'code-copy-btn';
-    btn.textContent = LABEL;
-    btn.setAttribute('aria-label', 'Copy code to clipboard');
+    btn.innerHTML = COPY_SVG;
+    btn.setAttribute('aria-label', 'Copy code');
+    btn.title = 'Copy';
 
     btn.addEventListener('click', async () => {
       try {
@@ -30,11 +31,15 @@
         try { document.execCommand('copy'); } catch (_) {}
         sel.removeAllRanges();
       }
-      btn.textContent = COPIED;
+      btn.innerHTML = CHECK_SVG;
       btn.classList.add('copied');
+      btn.setAttribute('aria-label', 'Copied');
+      btn.title = 'Copied';
       setTimeout(() => {
-        btn.textContent = LABEL;
+        btn.innerHTML = COPY_SVG;
         btn.classList.remove('copied');
+        btn.setAttribute('aria-label', 'Copy code');
+        btn.title = 'Copy';
       }, 1500);
     });
 

--- a/js/copy.js
+++ b/js/copy.js
@@ -1,0 +1,53 @@
+// Adds a "Copy" button to every <pre><code> block on the page.
+// Idempotent: the button is only added once per <pre>.
+(function () {
+  const LABEL = "Copy";
+  const COPIED = "Copied";
+
+  function attach(pre) {
+    if (pre.querySelector(':scope > .code-copy-btn')) return;
+    const code = pre.querySelector('code');
+    if (!code) return;
+
+    pre.classList.add('has-copy-btn');
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'code-copy-btn';
+    btn.textContent = LABEL;
+    btn.setAttribute('aria-label', 'Copy code to clipboard');
+
+    btn.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(code.textContent);
+      } catch (e) {
+        // Fallback for older browsers / file:// pages
+        const range = document.createRange();
+        range.selectNodeContents(code);
+        const sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+        try { document.execCommand('copy'); } catch (_) {}
+        sel.removeAllRanges();
+      }
+      btn.textContent = COPIED;
+      btn.classList.add('copied');
+      setTimeout(() => {
+        btn.textContent = LABEL;
+        btn.classList.remove('copied');
+      }, 1500);
+    });
+
+    pre.prepend(btn);
+  }
+
+  function init() {
+    document.querySelectorAll('pre > code').forEach(c => attach(c.parentElement));
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/llm/index.html
+++ b/llm/index.html
@@ -509,5 +509,6 @@ while (!done) {
       });
     });
   </script>
+  <script src="../js/copy.js" defer></script>
 </body>
 </html>

--- a/llm/index.html
+++ b/llm/index.html
@@ -394,7 +394,7 @@ while (!done) {
 
         <details class="faq-item">
           <summary>C++ で使うとき、ライセンスファイルはどこに置きますか?</summary>
-          <p>C++ バインディングはランタイムライブラリと同じ場所に <code>ailia.lic</code> を配置する必要があります:</p>
+          <p>C++ バインディングはランタイムライブラリと同じ場所に <code>ailia.lic</code> を配置する必要があります。</p>
           <p><strong>Windows:</strong> <code>ailia.dll</code> と同じフォルダ (サンプルでは <code>cpp/</code> 配下)。<br/>
           <strong>macOS:</strong> <code>~/Library/SHALO/</code><br/>
           <strong>Linux:</strong> <code>~/.shalo/</code></p>

--- a/sdk/index.html
+++ b/sdk/index.html
@@ -110,7 +110,7 @@ python3 yolox.py -v 0</code></pre>
 cd ailia-models-cpp
 git submodule init
 git submodule update</code></pre>
-            <p>macOS の場合のみ、dylib の quarantine 属性を解除します:</p>
+            <p>macOS の場合のみ、dylib の quarantine 属性を解除します。</p>
             <pre><code class="language-bash">./xattr.sh</code></pre>
             <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">サンプルリポジトリ</a>
             <a href="https://github.com/ailia-ai/ailia-sdk-cpp" target="_blank" class="card-link">バインディング</a>
@@ -478,7 +478,7 @@ println(output.size)</code></pre>
       <details class="faq-item">
         <summary>AILIAShape の x / y / z / w は何に対応しますか?</summary>
         <p><code>AILIAShape</code> は最大 4 次元までを <code>x</code> / <code>y</code> / <code>z</code> / <code>w</code> + <code>dim</code> で表します。<strong><code>x</code> が最も内側 (innermost、メモリ連続側) の軸、<code>w</code> が最も外側 (outermost) の軸</strong>です。たとえば numpy で <code>(batch, channel, height, width)</code> の 4 次元テンソルなら <code>w = batch</code>、<code>z = channel</code>、<code>y = height</code>、<code>x = width</code> が対応します。</p>
-        <p>有効な軸数は <code>dim</code> フィールドが示します:</p>
+        <p>有効な軸数は <code>dim</code> フィールドが示します。</p>
         <ul>
           <li><code>dim = 0</code>: スカラー (ONNX の rank-0 テンソル)</li>
           <li><code>dim = 1</code>: <code>x</code> のみ</li>
@@ -506,7 +506,7 @@ println(output.size)</code></pre>
       <details class="faq-item">
         <summary>メモリ消費量を抑えるには?</summary>
         <p>デフォルトは速度優先モードで、中間テンソルをすべてメモリに保持します。中間テンソルの再利用や定数の縮約を有効にすると、ピークメモリを削減できます。</p>
-        <p><strong>Python:</strong> <code>set_memory_mode</code> にビットフラグを渡します:</p>
+        <p><strong>Python:</strong> <code>set_memory_mode</code> にビットフラグを渡します。</p>
         <pre class="code-block"><code class="language-python">memory_mode = ailia.get_memory_mode(
     reduce_constant=True,
     ignore_input_with_initializer=True,

--- a/sdk/index.html
+++ b/sdk/index.html
@@ -649,5 +649,6 @@ net.set_memory_mode(memory_mode)</code></pre>
       });
     });
   </script>
+  <script src="../js/copy.js" defer></script>
 </body>
 </html>

--- a/sdk/index.html
+++ b/sdk/index.html
@@ -109,10 +109,9 @@ python3 yolox.py -v 0</code></pre>
             <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-models-cpp.git
 cd ailia-models-cpp
 git submodule init
-git submodule update
-
-# macOS: clear the quarantine attribute on bundled dylibs
-./xattr.sh</code></pre>
+git submodule update</code></pre>
+            <p>macOS の場合のみ、dylib の quarantine 属性を解除します:</p>
+            <pre><code class="language-bash">./xattr.sh</code></pre>
             <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">サンプルリポジトリ</a>
             <a href="https://github.com/ailia-ai/ailia-sdk-cpp" target="_blank" class="card-link">バインディング</a>
           </div>

--- a/speech/index.html
+++ b/speech/index.html
@@ -720,5 +720,6 @@ speech.close()</code></pre>
       });
     });
   </script>
+  <script src="../js/copy.js" defer></script>
 </body>
 </html>

--- a/speech/index.html
+++ b/speech/index.html
@@ -107,10 +107,9 @@ python3 example_ailia_speech.py</code></pre>
             <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-models-cpp.git
 cd ailia-models-cpp
 git submodule init
-git submodule update
-
-# macOS: dylib の quarantine 属性を解除
-./xattr.sh</code></pre>
+git submodule update</code></pre>
+            <p>macOS の場合のみ、dylib の quarantine 属性を解除します:</p>
+            <pre><code class="language-bash">./xattr.sh</code></pre>
             <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">サンプルリポジトリ</a>
             <a href="https://github.com/ailia-ai/ailia-models-cpp/blob/master/audio_processing/whisper/whisper.cpp" target="_blank" class="card-link">whisper.cpp サンプル</a>
           </div>

--- a/speech/index.html
+++ b/speech/index.html
@@ -108,7 +108,7 @@ python3 example_ailia_speech.py</code></pre>
 cd ailia-models-cpp
 git submodule init
 git submodule update</code></pre>
-            <p>macOS の場合のみ、dylib の quarantine 属性を解除します:</p>
+            <p>macOS の場合のみ、dylib の quarantine 属性を解除します。</p>
             <pre><code class="language-bash">./xattr.sh</code></pre>
             <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">サンプルリポジトリ</a>
             <a href="https://github.com/ailia-ai/ailia-models-cpp/blob/master/audio_processing/whisper/whisper.cpp" target="_blank" class="card-link">whisper.cpp サンプル</a>
@@ -551,7 +551,7 @@ speech.close()</code></pre>
 
         <details class="faq-item">
           <summary>固有名詞や専門用語の認識精度を上げるには?</summary>
-          <p>3 つの方法を組み合わせられます:</p>
+          <p>3 つの方法を組み合わせられます。</p>
           <p><strong>Prompt</strong> — 想定される単語の短いリスト (例: <code>"hardware software"</code>) を渡してデコードをバイアスします。</p>
           <p><strong>Constraints</strong> — 音声コマンド UI 向けに、文字集合や語彙 (例: <code>"command1,command2"</code>) でデコードを制限します。</p>
           <p><strong>自動補正辞書</strong> — <code>OpenDictionary</code> API で <code>phonetic,correct</code> 置換の CSV を読み込みます。</p>
@@ -569,7 +569,7 @@ speech.close()</code></pre>
 
         <details class="faq-item">
           <summary>C++ ではライセンスファイルをどこに置きますか?</summary>
-          <p>C++ バインディングはランタイムライブラリと同じ場所に <code>ailia.lic</code> を配置する必要があります:</p>
+          <p>C++ バインディングはランタイムライブラリと同じ場所に <code>ailia.lic</code> を配置する必要があります。</p>
           <p><strong>Windows:</strong> <code>ailia.dll</code> と同じフォルダ (サンプルでは <code>cpp/</code> 配下)。<br/>
           <strong>macOS:</strong> <code>~/Library/SHALO/</code><br/>
           <strong>Linux:</strong> <code>~/.shalo/</code></p>

--- a/tflite/index.html
+++ b/tflite/index.html
@@ -528,5 +528,6 @@ tflite.close()</code></pre>
       });
     });
   </script>
+  <script src="../js/copy.js" defer></script>
 </body>
 </html>

--- a/tflite/index.html
+++ b/tflite/index.html
@@ -108,10 +108,9 @@ python3 yolox.py -v 0</code></pre>
             <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-models-cpp.git
 cd ailia-models-cpp
 git submodule init
-git submodule update
-
-# macOS: dylib の quarantine 属性を解除
-./xattr.sh</code></pre>
+git submodule update</code></pre>
+            <p>macOS の場合のみ、dylib の quarantine 属性を解除します:</p>
+            <pre><code class="language-bash">./xattr.sh</code></pre>
             <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">サンプルリポジトリ</a>
             <a href="https://github.com/ailia-ai/ailia-models-cpp/tree/master/object_detection/yolox_tflite" target="_blank" class="card-link">yolox_tflite サンプル</a>
           </div>

--- a/tflite/index.html
+++ b/tflite/index.html
@@ -109,7 +109,7 @@ python3 yolox.py -v 0</code></pre>
 cd ailia-models-cpp
 git submodule init
 git submodule update</code></pre>
-            <p>macOS の場合のみ、dylib の quarantine 属性を解除します:</p>
+            <p>macOS の場合のみ、dylib の quarantine 属性を解除します。</p>
             <pre><code class="language-bash">./xattr.sh</code></pre>
             <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">サンプルリポジトリ</a>
             <a href="https://github.com/ailia-ai/ailia-models-cpp/tree/master/object_detection/yolox_tflite" target="_blank" class="card-link">yolox_tflite サンプル</a>

--- a/tokenizer/index.html
+++ b/tokenizer/index.html
@@ -424,7 +424,7 @@ val text = tokenizer.decode(ids)</code></pre>
 
         <details class="faq-item">
           <summary>各トークナイザに必要な追加ファイルは?</summary>
-          <p>Whisper / CLIP / GPT-2 は単体で完結します。それ以外のトークナイザは関連ファイルを同じ場所に配置する必要があります:</p>
+          <p>Whisper / CLIP / GPT-2 は単体で完結します。それ以外のトークナイザは関連ファイルを同じ場所に配置する必要があります。</p>
           <p><strong>SentencePiece</strong> (T5 / XLM-RoBERTa / Marian / Llama / Gemma): <code>spiece.model</code> / <code>tokenizer.model</code> / <code>source.spm</code>。<br/>
           <strong>BERT (英語):</strong> <code>vocab.txt</code> + <code>tokenizer_config.json</code>。<br/>
           <strong>BERT 日本語:</strong> ipadic 辞書 + <code>vocab.txt</code> (NFKC 正規化は自動)。<br/>
@@ -435,7 +435,7 @@ val text = tokenizer.decode(ids)</code></pre>
 
         <details class="faq-item">
           <summary>C++ で使うとき、ライセンスファイルはどこに置きますか?</summary>
-          <p>C++ バインディングはランタイムライブラリと同じ場所に <code>ailia.lic</code> を配置する必要があります:</p>
+          <p>C++ バインディングはランタイムライブラリと同じ場所に <code>ailia.lic</code> を配置する必要があります。</p>
           <p><strong>Windows:</strong> <code>ailia.dll</code> と同じフォルダ (サンプルでは <code>cpp/</code> 配下)。<br/>
           <strong>macOS:</strong> <code>~/Library/SHALO/</code><br/>
           <strong>Linux:</strong> <code>~/.shalo/</code></p>

--- a/tokenizer/index.html
+++ b/tokenizer/index.html
@@ -537,5 +537,6 @@ val text = tokenizer.decode(ids)</code></pre>
       });
     });
   </script>
+  <script src="../js/copy.js" defer></script>
 </body>
 </html>

--- a/tracker/index.html
+++ b/tracker/index.html
@@ -83,10 +83,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-models-cpp.git
 cd ailia-models-cpp
 git submodule init
-git submodule update
-
-# macOS: dylib の quarantine 属性を解除
-./xattr.sh</code></pre>
+git submodule update</code></pre>
+            <p>macOS の場合のみ、dylib の quarantine 属性を解除します:</p>
+            <pre><code class="language-bash">./xattr.sh</code></pre>
             <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">サンプルリポジトリ</a>
             <a href="https://github.com/ailia-ai/ailia-models-cpp/tree/master/object_tracking/bytetrack" target="_blank" class="card-link">bytetrack サンプル</a>
           </div>

--- a/tracker/index.html
+++ b/tracker/index.html
@@ -84,7 +84,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 cd ailia-models-cpp
 git submodule init
 git submodule update</code></pre>
-            <p>macOS の場合のみ、dylib の quarantine 属性を解除します:</p>
+            <p>macOS の場合のみ、dylib の quarantine 属性を解除します。</p>
             <pre><code class="language-bash">./xattr.sh</code></pre>
             <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">サンプルリポジトリ</a>
             <a href="https://github.com/ailia-ai/ailia-models-cpp/tree/master/object_tracking/bytetrack" target="_blank" class="card-link">bytetrack サンプル</a>
@@ -376,7 +376,7 @@ tracker.close()</code></pre>
 
       <details class="faq-item">
         <summary>モデルファイルはどこからダウンロードできますか?</summary>
-        <p>YOLOX-S の重みと prototxt:</p>
+        <p>YOLOX-S の重みと prototxt。</p>
         <p><a href="https://storage.googleapis.com/ailia-models/yolox/yolox_s.opt.onnx" target="_blank">yolox_s.opt.onnx</a><br/>
         <a href="https://storage.googleapis.com/ailia-models/yolox/yolox_s.opt.onnx.prototxt" target="_blank">yolox_s.opt.onnx.prototxt</a></p>
         <p>両方のファイルをサンプルバイナリと同じフォルダに配置してください。</p>
@@ -409,7 +409,7 @@ tracker.close()</code></pre>
 
       <details class="faq-item">
         <summary>ライセンスはどう扱われますか?</summary>
-        <p>C++ バインディングは評価版パッケージの <code>ailia.lic</code> をランタイムライブラリと同じ場所に配置する必要があります:</p>
+        <p>C++ バインディングは評価版パッケージの <code>ailia.lic</code> をランタイムライブラリと同じ場所に配置する必要があります。</p>
         <p><strong>Windows:</strong> <code>ailia.dll</code> と同じフォルダ。<br/>
         <strong>macOS:</strong> <code>~/Library/SHALO/</code><br/>
         <strong>Linux:</strong> <code>~/.shalo/</code></p>

--- a/tracker/index.html
+++ b/tracker/index.html
@@ -489,5 +489,6 @@ tracker.close()</code></pre>
       });
     });
   </script>
+  <script src="../js/copy.js" defer></script>
 </body>
 </html>

--- a/voice/index.html
+++ b/voice/index.html
@@ -651,5 +651,6 @@ pyopenjtalk.mecab_dict_index("userdic.csv", "userdic.dic")</code></pre>
       });
     });
   </script>
+  <script src="../js/copy.js" defer></script>
 </body>
 </html>

--- a/voice/index.html
+++ b/voice/index.html
@@ -106,10 +106,9 @@ python3 example_ailia_voice.py</code></pre>
             <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-models-cpp.git
 cd ailia-models-cpp
 git submodule init
-git submodule update
-
-# macOS: dylib の quarantine 属性を解除
-./xattr.sh</code></pre>
+git submodule update</code></pre>
+            <p>macOS の場合のみ、dylib の quarantine 属性を解除します:</p>
+            <pre><code class="language-bash">./xattr.sh</code></pre>
             <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">サンプルリポジトリ</a>
             <a href="https://github.com/ailia-ai/ailia-models-cpp/tree/master/audio_processing/gpt-sovits-v2-pro" target="_blank" class="card-link">gpt-sovits-v2-pro サンプル</a>
           </div>

--- a/voice/index.html
+++ b/voice/index.html
@@ -107,7 +107,7 @@ python3 example_ailia_voice.py</code></pre>
 cd ailia-models-cpp
 git submodule init
 git submodule update</code></pre>
-            <p>macOS の場合のみ、dylib の quarantine 属性を解除します:</p>
+            <p>macOS の場合のみ、dylib の quarantine 属性を解除します。</p>
             <pre><code class="language-bash">./xattr.sh</code></pre>
             <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">サンプルリポジトリ</a>
             <a href="https://github.com/ailia-ai/ailia-models-cpp/tree/master/audio_processing/gpt-sovits-v2-pro" target="_blank" class="card-link">gpt-sovits-v2-pro サンプル</a>
@@ -516,7 +516,7 @@ val result = voice.synthesizeVoice(feature)</code></pre>
 
         <details class="faq-item">
           <summary>独自の発音辞書を作成するには?</summary>
-          <p>ailia Voice は日本語の音素変換に OpenJtalk を内蔵しています。発音を上書きするには、MeCab 形式の <code>userdic.csv</code> を用意し (末尾の <code>0/5</code> は 5 モーラ・アクセント位置 0 を表します)、pyopenjtalk でバイナリ <code>.dic</code> に変換します:</p>
+          <p>ailia Voice は日本語の音素変換に OpenJtalk を内蔵しています。発音を上書きするには、MeCab 形式の <code>userdic.csv</code> を用意し (末尾の <code>0/5</code> は 5 モーラ・アクセント位置 0 を表します)、pyopenjtalk でバイナリ <code>.dic</code> に変換します。</p>
           <pre><code class="language-bash">import pyopenjtalk
 pyopenjtalk.mecab_dict_index("userdic.csv", "userdic.dic")</code></pre>
           <p>その後、Python では <code>initialize_model()</code> に <code>user_dict_path</code> を渡し、C では <code>ailiaVoiceSetUserDictionary</code> を呼び出します。v3 用の <a href="https://storage.googleapis.com/ailia-models/gpt-sovits-v3/user.dict" target="_blank">標準ユーザー辞書</a> も利用できます。</p>
@@ -529,7 +529,7 @@ pyopenjtalk.mecab_dict_index("userdic.csv", "userdic.dic")</code></pre>
 
         <details class="faq-item">
           <summary>C++ で使うとき、ライセンスファイルはどこに置きますか?</summary>
-          <p>C++ バインディングはランタイムライブラリと同じ場所に <code>ailia.lic</code> を配置する必要があります:</p>
+          <p>C++ バインディングはランタイムライブラリと同じ場所に <code>ailia.lic</code> を配置する必要があります。</p>
           <p><strong>Windows:</strong> <code>ailia.dll</code> と同じフォルダ (サンプルでは <code>cpp/</code> 配下)。<br/>
           <strong>macOS:</strong> <code>~/Library/SHALO/</code><br/>
           <strong>Linux:</strong> <code>~/.shalo/</code></p>


### PR DESCRIPTION
Inject a small "Copy" button into the top-right of each <pre><code> across all 16 doc pages. New js/copy.js does a single DOM pass on load, prepending a button that uses navigator.clipboard.writeText (falling back to document.execCommand on older browsers / file://). The button text flips to "Copied" for 1.5s after a click. CSS lives in css/common.css alongside .code-block.

Skipped for <pre> without a child <code> (e.g. the mermaid state diagrams), and idempotent so the script can run any time without duplicating buttons.