### PR TITLE
docs(llm/cpp): align Getting Started with gemma4 sample

### DIFF
--- a/llm/cpp/en/setup.html
+++ b/llm/cpp/en/setup.html
@@ -72,30 +72,25 @@ Compiler setup</h1>
 Windows</h2>
 <p>Requirements:</p><ul>
 <li>VisualStudio 2019 and higher</li>
+<li>CMake</li>
 </ul>
 <h2><a class="anchor" id="autotoc_md18"></a>
 macOS</h2>
 <p>Requirements:</p><ul>
 <li>Xcode 14.2 and higher</li>
+<li>CMake</li>
 </ul>
 <h2><a class="anchor" id="autotoc_md19"></a>
 Linux</h2>
 <p>Requirements:</p><ul>
 <li>clang</li>
+<li>CMake</li>
 </ul>
 <h1><a class="anchor" id="autotoc_md20"></a>
 Building the sample</h1>
-<p>Move to the <code>cpp</code> folder, then run the command corresponding to your OS as described below.</p>
-<h2><a class="anchor" id="autotoc_md21"></a>
-Windows</h2>
-<div class="fragment"><div class="line">cl gemma4.cpp ailia_llm.lib</div>
-</div><!-- fragment --><h2><a class="anchor" id="autotoc_md22"></a>
-macOS</h2>
-<div class="fragment"><div class="line">clang++ -o gemma4 gemma4.cpp libailia_llm.dylib -Wl,-rpath,./ -std=c++17</div>
-</div><!-- fragment --><h2><a class="anchor" id="autotoc_md23"></a>
-Linux</h2>
-<div class="fragment"><div class="line">export LD_LIBRARY_PATH=./</div>
-<div class="line">g++ -o gemma4 gemma4.cpp libailia_llm.so</div>
+<p>Move to the sample folder (for example <code>large_language_model/gemma4</code>) and build with CMake.</p>
+<div class="fragment"><div class="line">cmake .</div>
+<div class="line">cmake --build .</div>
 </div><!-- fragment --><h1><a class="anchor" id="autotoc_md24"></a>
 Running the sample</h1>
 <p>Use the launcher script (<code>gemma4.sh</code> on macOS/Linux or <code>gemma4.bat</code> on Windows). The script automatically downloads the model file if it does not yet exist, and then runs the executable.</p>

--- a/llm/cpp/en/setup.html
+++ b/llm/cpp/en/setup.html
@@ -88,22 +88,24 @@ Building the sample</h1>
 <p>Move to the <code>cpp</code> folder, then run the command corresponding to your OS as described below.</p>
 <h2><a class="anchor" id="autotoc_md21"></a>
 Windows</h2>
-<div class="fragment"><div class="line">cl ailia_llm_sample.cpp ailia_llm.lib</div>
+<div class="fragment"><div class="line">cl gemma4.cpp ailia_llm.lib</div>
 </div><!-- fragment --><h2><a class="anchor" id="autotoc_md22"></a>
 macOS</h2>
-<div class="fragment"><div class="line">clang++ -o ailia_llm_sample ailia_llm_sample.cpp libailia_llm.dylib -Wl,-rpath,./ -std=c++17</div>
+<div class="fragment"><div class="line">clang++ -o gemma4 gemma4.cpp libailia_llm.dylib -Wl,-rpath,./ -std=c++17</div>
 </div><!-- fragment --><h2><a class="anchor" id="autotoc_md23"></a>
 Linux</h2>
 <div class="fragment"><div class="line">export LD_LIBRARY_PATH=./</div>
-<div class="line">g++ -o ailia_llm_sample ailia_llm_sample.cpp libailia_llm.so</div>
+<div class="line">g++ -o gemma4 gemma4.cpp libailia_llm.so</div>
 </div><!-- fragment --><h1><a class="anchor" id="autotoc_md24"></a>
 Model file download</h1>
-<p>Download the specified model file and place it in the models folder.</p>
-<p><a href="https://huggingface.co/bartowski/gemma-2-2b-it-GGUF/resolve/main/gemma-2-2b-it-Q4_K_M.gguf?download=true">https://huggingface.co/bartowski/gemma-2-2b-it-GGUF/resolve/main/gemma-2-2b-it-Q4_K_M.gguf?download=true</a></p>
+<p>Download the specified model file and place it in the same folder as the executable.</p>
+<p><a href="https://storage.googleapis.com/ailia-models/gemma/gemma-4-E2B-it-Q4_K_M.gguf">https://storage.googleapis.com/ailia-models/gemma/gemma-4-E2B-it-Q4_K_M.gguf</a></p>
 <h1><a class="anchor" id="autotoc_md25"></a>
 Running the sample</h1>
 <p>Run the sample by executing the command below.</p>
-<div class="fragment"><div class="line">./ailia_llm_sample</div>
+<div class="fragment"><div class="line">./gemma4 -m gemma-4-E2B-it-Q4_K_M.gguf</div>
+</div><!-- fragment --><p>You can also use the provided launcher script (<code>gemma4.sh</code> on macOS/Linux or <code>gemma4.bat</code> on Windows), which automatically downloads the model file if it does not yet exist and then runs the executable.</p>
+<div class="fragment"><div class="line">./gemma4.sh</div>
 </div><!-- fragment --><h1><a class="anchor" id="autotoc_md26"></a>
 Platform-specific remarks</h1>
 <h2><a class="anchor" id="autotoc_md27"></a>

--- a/llm/cpp/en/setup.html
+++ b/llm/cpp/en/setup.html
@@ -97,15 +97,16 @@ Linux</h2>
 <div class="fragment"><div class="line">export LD_LIBRARY_PATH=./</div>
 <div class="line">g++ -o gemma4 gemma4.cpp libailia_llm.so</div>
 </div><!-- fragment --><h1><a class="anchor" id="autotoc_md24"></a>
-Model file download</h1>
-<p>Download the specified model file and place it in the same folder as the executable.</p>
-<p><a href="https://storage.googleapis.com/ailia-models/gemma/gemma-4-E2B-it-Q4_K_M.gguf">https://storage.googleapis.com/ailia-models/gemma/gemma-4-E2B-it-Q4_K_M.gguf</a></p>
-<h1><a class="anchor" id="autotoc_md25"></a>
 Running the sample</h1>
-<p>Run the sample by executing the command below.</p>
-<div class="fragment"><div class="line">./gemma4 -m gemma-4-E2B-it-Q4_K_M.gguf</div>
-</div><!-- fragment --><p>You can also use the provided launcher script (<code>gemma4.sh</code> on macOS/Linux or <code>gemma4.bat</code> on Windows), which automatically downloads the model file if it does not yet exist and then runs the executable.</p>
+<p>Use the launcher script (<code>gemma4.sh</code> on macOS/Linux or <code>gemma4.bat</code> on Windows). The script automatically downloads the model file if it does not yet exist, and then runs the executable.</p>
+<h2>macOS / Linux</h2>
 <div class="fragment"><div class="line">./gemma4.sh</div>
+</div><!-- fragment --><h2>Windows</h2>
+<div class="fragment"><div class="line">gemma4.bat</div>
+</div><!-- fragment --><p>If you want to download the model file manually, you can obtain it from the URL below and place it in the same folder as the executable.</p>
+<p><a href="https://storage.googleapis.com/ailia-models/gemma/gemma-4-E2B-it-Q4_K_M.gguf">https://storage.googleapis.com/ailia-models/gemma/gemma-4-E2B-it-Q4_K_M.gguf</a></p>
+<p>Then run the executable directly:</p>
+<div class="fragment"><div class="line">./gemma4 -m gemma-4-E2B-it-Q4_K_M.gguf</div>
 </div><!-- fragment --><h1><a class="anchor" id="autotoc_md26"></a>
 Platform-specific remarks</h1>
 <h2><a class="anchor" id="autotoc_md27"></a>

--- a/llm/cpp/jp/setup.html
+++ b/llm/cpp/jp/setup.html
@@ -82,22 +82,24 @@ Linux</h2>
 <p>cppフォルダに移動して、プラットフォーム別のビルドコマンドを実行します。</p>
 <h2><a class="anchor" id="autotoc_md9"></a>
 Windows</h2>
-<div class="fragment"><div class="line">cl ailia_llm_sample.cpp ailia_llm.lib</div>
+<div class="fragment"><div class="line">cl gemma4.cpp ailia_llm.lib</div>
 </div><!-- fragment --><h2><a class="anchor" id="autotoc_md10"></a>
 macOS</h2>
-<div class="fragment"><div class="line">clang++ -o ailia_llm_sample ailia_llm_sample.cpp libailia_llm.dylib -Wl,-rpath,./ -std=c++17</div>
+<div class="fragment"><div class="line">clang++ -o gemma4 gemma4.cpp libailia_llm.dylib -Wl,-rpath,./ -std=c++17</div>
 </div><!-- fragment --><h2><a class="anchor" id="autotoc_md11"></a>
 Linux</h2>
 <div class="fragment"><div class="line">export LD_LIBRARY_PATH=./</div>
-<div class="line">g++ -o ailia_llm_sample ailia_llm_sample.cpp libailia_llm.so</div>
+<div class="line">g++ -o gemma4 gemma4.cpp libailia_llm.so</div>
 </div><!-- fragment --><h1><a class="anchor" id="autotoc_md12"></a>
 モデルファイルのダウンロード</h1>
-<p>下記のモデルファイルをダウンロードして、modelsフォルダに配置します。</p>
-<p><a href="https://huggingface.co/bartowski/gemma-2-2b-it-GGUF/resolve/main/gemma-2-2b-it-Q4_K_M.gguf?download=true">https://huggingface.co/bartowski/gemma-2-2b-it-GGUF/resolve/main/gemma-2-2b-it-Q4_K_M.gguf?download=true</a></p>
+<p>下記のモデルファイルをダウンロードして、実行ファイルと同じフォルダに配置します。</p>
+<p><a href="https://storage.googleapis.com/ailia-models/gemma/gemma-4-E2B-it-Q4_K_M.gguf">https://storage.googleapis.com/ailia-models/gemma/gemma-4-E2B-it-Q4_K_M.gguf</a></p>
 <h1><a class="anchor" id="autotoc_md13"></a>
 サンプルの実行</h1>
 <p>下記のコマンドでサンプルを実行します。</p>
-<div class="fragment"><div class="line">./ailia_llm_sample</div>
+<div class="fragment"><div class="line">./gemma4 -m gemma-4-E2B-it-Q4_K_M.gguf</div>
+</div><!-- fragment --><p>付属の起動スクリプト(macOS/Linuxでは<code>gemma4.sh</code>、Windowsでは<code>gemma4.bat</code>)を利用することもできます。スクリプトはモデルファイルが存在しない場合は自動でダウンロードし、その後実行ファイルを起動します。</p>
+<div class="fragment"><div class="line">./gemma4.sh</div>
 </div><!-- fragment --><h1><a class="anchor" id="autotoc_md14"></a>
 プラットフォーム別の注意点</h1>
 <h2><a class="anchor" id="autotoc_md15"></a>

--- a/llm/cpp/jp/setup.html
+++ b/llm/cpp/jp/setup.html
@@ -70,26 +70,18 @@ $(function() {
 コンパイラのセットアップ</h1>
 <h2><a class="anchor" id="autotoc_md5"></a>
 Windows</h2>
-<p>VisualStudio 2019以降が必要です。</p>
+<p>VisualStudio 2019以降、およびCMakeが必要です。</p>
 <h2><a class="anchor" id="autotoc_md6"></a>
 macOS</h2>
-<p>Xcode 14.2以降が必要です。</p>
+<p>Xcode 14.2以降、およびCMakeが必要です。</p>
 <h2><a class="anchor" id="autotoc_md7"></a>
 Linux</h2>
-<p>clangが必要です。</p>
+<p>clangとCMakeが必要です。</p>
 <h1><a class="anchor" id="autotoc_md8"></a>
 サンプルのビルド</h1>
-<p>cppフォルダに移動して、プラットフォーム別のビルドコマンドを実行します。</p>
-<h2><a class="anchor" id="autotoc_md9"></a>
-Windows</h2>
-<div class="fragment"><div class="line">cl gemma4.cpp ailia_llm.lib</div>
-</div><!-- fragment --><h2><a class="anchor" id="autotoc_md10"></a>
-macOS</h2>
-<div class="fragment"><div class="line">clang++ -o gemma4 gemma4.cpp libailia_llm.dylib -Wl,-rpath,./ -std=c++17</div>
-</div><!-- fragment --><h2><a class="anchor" id="autotoc_md11"></a>
-Linux</h2>
-<div class="fragment"><div class="line">export LD_LIBRARY_PATH=./</div>
-<div class="line">g++ -o gemma4 gemma4.cpp libailia_llm.so</div>
+<p>サンプルフォルダ(例: <code>large_language_model/gemma4</code>)に移動して、CMakeでビルドします。</p>
+<div class="fragment"><div class="line">cmake .</div>
+<div class="line">cmake --build .</div>
 </div><!-- fragment --><h1><a class="anchor" id="autotoc_md12"></a>
 サンプルの実行</h1>
 <p>付属の起動スクリプト(macOS/Linuxでは<code>gemma4.sh</code>、Windowsでは<code>gemma4.bat</code>)を実行します。モデルファイルが存在しない場合は自動でダウンロードされ、その後実行ファイルが起動します。</p>

--- a/llm/cpp/jp/setup.html
+++ b/llm/cpp/jp/setup.html
@@ -91,15 +91,16 @@ Linux</h2>
 <div class="fragment"><div class="line">export LD_LIBRARY_PATH=./</div>
 <div class="line">g++ -o gemma4 gemma4.cpp libailia_llm.so</div>
 </div><!-- fragment --><h1><a class="anchor" id="autotoc_md12"></a>
-モデルファイルのダウンロード</h1>
-<p>下記のモデルファイルをダウンロードして、実行ファイルと同じフォルダに配置します。</p>
-<p><a href="https://storage.googleapis.com/ailia-models/gemma/gemma-4-E2B-it-Q4_K_M.gguf">https://storage.googleapis.com/ailia-models/gemma/gemma-4-E2B-it-Q4_K_M.gguf</a></p>
-<h1><a class="anchor" id="autotoc_md13"></a>
 サンプルの実行</h1>
-<p>下記のコマンドでサンプルを実行します。</p>
-<div class="fragment"><div class="line">./gemma4 -m gemma-4-E2B-it-Q4_K_M.gguf</div>
-</div><!-- fragment --><p>付属の起動スクリプト(macOS/Linuxでは<code>gemma4.sh</code>、Windowsでは<code>gemma4.bat</code>)を利用することもできます。スクリプトはモデルファイルが存在しない場合は自動でダウンロードし、その後実行ファイルを起動します。</p>
+<p>付属の起動スクリプト(macOS/Linuxでは<code>gemma4.sh</code>、Windowsでは<code>gemma4.bat</code>)を実行します。モデルファイルが存在しない場合は自動でダウンロードされ、その後実行ファイルが起動します。</p>
+<h2>macOS / Linux</h2>
 <div class="fragment"><div class="line">./gemma4.sh</div>
+</div><!-- fragment --><h2>Windows</h2>
+<div class="fragment"><div class="line">gemma4.bat</div>
+</div><!-- fragment --><p>モデルファイルを手動でダウンロードする場合は、下記URLから取得して実行ファイルと同じフォルダに配置してください。</p>
+<p><a href="https://storage.googleapis.com/ailia-models/gemma/gemma-4-E2B-it-Q4_K_M.gguf">https://storage.googleapis.com/ailia-models/gemma/gemma-4-E2B-it-Q4_K_M.gguf</a></p>
+<p>その後、実行ファイルを直接起動できます。</p>
+<div class="fragment"><div class="line">./gemma4 -m gemma-4-E2B-it-Q4_K_M.gguf</div>
 </div><!-- fragment --><h1><a class="anchor" id="autotoc_md14"></a>
 プラットフォーム別の注意点</h1>
 <h2><a class="anchor" id="autotoc_md15"></a>


### PR DESCRIPTION
Update the C++ Getting Started page to use the gemma4 sample from ailia-models-cpp (file names, model URL on ailia-models storage, and the launcher script) instead of the old ailia_llm_sample / Hugging Face gemma-2-2b-it references.