### PR TITLE
docs(llm): point C++ Getting Started to gemma4 sample

### DIFF
--- a/en/llm/index.html
+++ b/en/llm/index.html
@@ -101,19 +101,35 @@ python3 example_ailia_llm.py</code></pre>
         <div class="steps-grid">
           <div class="step">
             <div class="step-number">1</div>
-            <h3>Get Evaluation Package</h3>
-            <p>Apply for the free trial to obtain the evaluation package, which contains the C++ binding (<code>ailia_llm.h</code>), the runtime library (<code>ailia_llm</code>), and a runnable sample.</p>
-            <a href="https://axip-console.appspot.com/trial/terms/AILIA-LLM?lang=en" target="_blank" class="card-link">Apply for Free Trial</a>
+            <h3>Clone Samples</h3>
+            <p>Clone the C++ sample repository and initialize submodules. The ailia-llm-cpp binding is included as a submodule.</p>
+            <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-models-cpp.git
+cd ailia-models-cpp
+git submodule init
+git submodule update</code></pre>
+            <p>On macOS only, clear the quarantine attribute on the bundled dylibs:</p>
+            <pre><code class="language-bash">./xattr.sh</code></pre>
+            <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">Sample Repository</a>
+            <a href="https://github.com/ailia-ai/ailia-models-cpp/tree/master/large_language_model/gemma4" target="_blank" class="card-link">gemma4 sample</a>
           </div>
           <div class="step">
             <div class="step-number">2</div>
-            <h3>Download a Model &amp; Run</h3>
-            <p>Place a GGUF file (e.g. Gemma 2-2B from Hugging Face) under <code>models/</code>, then build and run the sample.</p>
-            <pre><code class="language-bash"># macOS
-clang++ -o ailia_llm_sample ailia_llm_sample.cpp \
-  libailia_llm.dylib -Wl,-rpath,./ -std=c++17
+            <h3>Build &amp; Run</h3>
+            <p>Fetch the one-month evaluation license, install CMake, build, and run the gemma4 sample. <code>gemma4.sh</code> downloads the GGUF model on first run, then streams the chat response.</p>
+            <pre><code class="language-bash"># Fetch a one-month evaluation license
+cd ailia
+python3 download_license.py
+cd ..
 
-./ailia_llm_sample</code></pre>
+# macOS
+brew install cmake
+# Linux: apt install cmake
+# Windows: install CMake and Visual Studio
+
+cmake -DWITH_OPENCV=OFF .
+cmake --build .
+cd large_language_model/gemma4
+./gemma4.sh    # use gemma4.bat on Windows</code></pre>
             <a href="../../llm/cpp/en/setup.html" class="card-link">Full C++ Setup Guide</a>
           </div>
         </div>

--- a/llm/index.html
+++ b/llm/index.html
@@ -101,20 +101,36 @@ python3 example_ailia_llm.py</code></pre>
         <div class="steps-grid">
           <div class="step">
             <div class="step-number">1</div>
-            <h3>評価版を入手</h3>
-            <p>無料トライアルに申し込むと、C++ バインディング (<code>ailia_llm.h</code>)、ランタイムライブラリ (<code>ailia_llm</code>)、実行可能サンプルを含む評価版パッケージを入手できます。</p>
-            <a href="https://axip-console.appspot.com/trial/terms/AILIA-LLM" target="_blank" class="card-link">無料トライアルを申し込む</a>
+            <h3>サンプルをクローン</h3>
+            <p>C++ サンプルリポジトリをクローンしてサブモジュールを初期化します。ailia-llm-cpp バインディングはサブモジュールとして含まれています。</p>
+            <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-models-cpp.git
+cd ailia-models-cpp
+git submodule init
+git submodule update</code></pre>
+            <p>macOS の場合のみ、dylib の quarantine 属性を解除します。</p>
+            <pre><code class="language-bash">./xattr.sh</code></pre>
+            <a href="https://github.com/ailia-ai/ailia-models-cpp" target="_blank" class="card-link">サンプルリポジトリ</a>
+            <a href="https://github.com/ailia-ai/ailia-models-cpp/tree/master/large_language_model/gemma4" target="_blank" class="card-link">gemma4 サンプル</a>
           </div>
           <div class="step">
             <div class="step-number">2</div>
-            <h3>サンプルを実行</h3>
-            <p><code>ailia-models-cpp</code> をクローンし、<code>large_language_model/gemma4</code> サンプルを CMake でビルドします。付属の起動スクリプト (<code>gemma4.sh</code> / <code>gemma4.bat</code>) を実行すると、初回は Gemma 3 4B の GGUF ファイルを自動でダウンロードし、チャット応答をストリーミング生成します。</p>
-            <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-models-cpp.git
-cd ailia-models-cpp/large_language_model/gemma4
-cmake .
+            <h3>ビルドして実行</h3>
+            <p>1 か月の評価ライセンスを取得し、CMake をインストールしてビルド、gemma4 サンプルを実行します。<code>gemma4.sh</code> がモデル GGUF ファイルを自動でダウンロードしてからチャット応答をストリーミング生成します。</p>
+            <pre><code class="language-bash"># 評価ライセンスを取得
+cd ailia
+python3 download_license.py
+cd ..
+
+# macOS
+brew install cmake
+# Linux: apt install cmake
+# Windows: install CMake and Visual Studio
+
+cmake -DWITH_OPENCV=OFF .
 cmake --build .
-./gemma4.sh</code></pre>
-            <a href="https://github.com/ailia-ai/ailia-models-cpp/tree/master/large_language_model/gemma4" target="_blank" class="card-link">gemma4 サンプル</a>
+cd large_language_model/gemma4
+./gemma4.sh    # use gemma4.bat on Windows</code></pre>
+            <a href="cpp/jp/setup.html" class="card-link">C++ セットアップガイド</a>
           </div>
         </div>
       </div>

--- a/llm/index.html
+++ b/llm/index.html
@@ -107,14 +107,14 @@ python3 example_ailia_llm.py</code></pre>
           </div>
           <div class="step">
             <div class="step-number">2</div>
-            <h3>モデルをダウンロードして実行</h3>
-            <p>GGUF ファイル (例: Hugging Face の Gemma 2-2B) を <code>models/</code> に配置し、サンプルをビルドして実行します。</p>
-            <pre><code class="language-bash"># macOS
-clang++ -o ailia_llm_sample ailia_llm_sample.cpp \
-  libailia_llm.dylib -Wl,-rpath,./ -std=c++17
-
-./ailia_llm_sample</code></pre>
-            <a href="../llm/cpp/en/setup.html" class="card-link">C++ セットアップガイド</a>
+            <h3>サンプルを実行</h3>
+            <p><code>ailia-models-cpp</code> をクローンし、<code>large_language_model/gemma4</code> サンプルを CMake でビルドします。付属の起動スクリプト (<code>gemma4.sh</code> / <code>gemma4.bat</code>) を実行すると、初回は Gemma 3 4B の GGUF ファイルを自動でダウンロードし、チャット応答をストリーミング生成します。</p>
+            <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-models-cpp.git
+cd ailia-models-cpp/large_language_model/gemma4
+cmake .
+cmake --build .
+./gemma4.sh</code></pre>
+            <a href="https://github.com/ailia-ai/ailia-models-cpp/tree/master/large_language_model/gemma4" target="_blank" class="card-link">gemma4 サンプル</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Update the C++ panel of the ailia LLM landing page to mirror the Python panel: clone ailia-models-cpp, build the gemma4 sample with CMake, and run gemma4.sh (which auto-downloads the GGUF model) instead of manually placing a Hugging Face GGUF and invoking clang++.