### PR TITLE
docs: add Windows on Arm (WoA) setup guide

### DIFF
--- a/en/sdk/index.html
+++ b/en/sdk/index.html
@@ -608,6 +608,10 @@ net.set_memory_mode(memory_mode)</code></pre>
     <div class="article-title">Evaluation version installable via pip</div>
     <div class="article-source">tech.ailia.ai</div>
   </a>
+  <a class="article-card" href="../setup/woa/">
+    <div class="article-title">Windows on Arm Setup Guide</div>
+    <div class="article-source">docs.ailia.ai</div>
+  </a>
   </div>
 </section>
 <!-- /Related Articles -->

--- a/en/setup/woa/index.html
+++ b/en/setup/woa/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5Q579RMM');</script>
+<!-- End Google Tag Manager -->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Windows on Arm Setup Guide - ailia SDK</title>
+  <meta name="description" content="How to set up Python, OpenCV, numpy, and ailia SDK on Windows on Arm (WoA).">
+  <link rel="canonical" href="https://docs.ailia.ai/en/setup/woa/">
+  <link rel="alternate" hreflang="en" href="https://docs.ailia.ai/en/setup/woa/">
+  <link rel="alternate" hreflang="ja" href="https://docs.ailia.ai/setup/woa/">
+  <link rel="alternate" hreflang="x-default" href="https://docs.ailia.ai/en/setup/woa/">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:locale:alternate" content="ja_JP">
+  <meta property="og:site_name" content="ailia Documentation">
+  <meta property="og:url" content="https://docs.ailia.ai/en/setup/woa/">
+  <meta property="og:title" content="Windows on Arm Setup Guide - ailia SDK">
+  <meta property="og:description" content="How to set up Python, OpenCV, numpy, and ailia SDK on Windows on Arm (WoA).">
+  <meta property="og:image" content="https://docs.ailia.ai/ailia_logo.png">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Windows on Arm Setup Guide - ailia SDK">
+  <meta name="twitter:description" content="How to set up Python, OpenCV, numpy, and ailia SDK on Windows on Arm (WoA).">
+  <meta name="twitter:image" content="https://docs.ailia.ai/ailia_logo.png">
+  <link rel="icon" type="image/png" href="../../../ailia_logo.png">
+  <link rel="stylesheet" href="../../../css/common.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+</head>
+<body>
+  <header>
+    <div class="header-inner">
+      <div class="logo">
+        <a href="https://docs.ailia.ai/en/" class="logo-icon"><img src="../../../ailia_logo.png" alt="ailia"></a>
+        <a href="../../" class="logo-text">ailia SDK Docs</a>
+      </div>
+      <button class="menu-toggle" aria-label="Open menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+      </button>
+      <div class="header-links">
+        <a href="../../">Top</a>
+        <a href="../../sdk/">SDK</a>
+        <a href="../../tflite/">TFLite</a>
+        <a href="../../llm/">LLM</a>
+        <a href="../../speech/">Speech</a>
+        <a href="../../voice/">Voice</a>
+        <a href="../../tokenizer/">Tokenizer</a>
+        <a href="../../tracker/">Tracker</a>
+        <a href="../../../setup/woa/" hreflang="ja" lang="ja">JA</a>
+      </div>
+    </div>
+  </header>
+
+  <section class="hero">
+    <h1>Windows on Arm Setup Guide</h1>
+    <p>How to set up Python, OpenCV, numpy, and ailia SDK on Windows on Arm (WoA).</p>
+  </section>
+
+  <div class="guide-content">
+
+    <h2>Overview</h2>
+    <p>Windows on Arm (WoA) is a Windows environment that runs on Arm processors. This guide explains how to set up ailia SDK on PCs equipped with Arm-based processors such as Snapdragon X Elite.</p>
+
+    <h2>Installing Python</h2>
+    <p>On Windows on Arm, you need to install the Arm native version of Python. Follow the official Arm guide below:</p>
+    <p><a href="https://learn.arm.com/install-guides/py-woa/" target="_blank">https://learn.arm.com/install-guides/py-woa/</a></p>
+
+    <div class="note">
+      <strong>Note:</strong> Make sure to install the Arm native version of Python, not the x86 version. Using the Arm native version provides optimal performance.
+    </div>
+
+    <h2>Installing numpy</h2>
+    <p>numpy can be installed via pip:</p>
+    <pre><code class="language-bash">pip3 install numpy</code></pre>
+    <p>This will install numpy 2.4.6.</p>
+
+    <h2>Installing OpenCV</h2>
+    <p>On Windows on Arm, install OpenCV Headless with the following command:</p>
+    <pre><code class="language-bash">python -m pip install opencv_python_headless-4.10.0.84-cp313-cp313-win_arm64.whl</code></pre>
+
+    <div class="note">
+      <strong>Note:</strong> OpenCV Headless does not include GUI functionality. Functions such as <code>cv2.imshow()</code> are not available. If you need to display images, save them to a file using <code>cv2.imwrite()</code> or use another library.
+    </div>
+
+    <h2>Installing ailia SDK</h2>
+    <p>From ailia SDK 1.7 onwards, you can install it via pip:</p>
+    <pre><code class="language-bash">pip3 install ailia</code></pre>
+
+  </div>
+
+  <footer>
+    <p><a href="https://ailia.ai/en/" target="_blank">ailia Inc.</a></p>
+    <p class="footer-copy">&copy; ailia Inc. All rights reserved.</p>
+  </footer>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <script>hljs.highlightAll();</script>
+  <script>
+    document.querySelectorAll('.menu-toggle').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const links = btn.parentElement.querySelector('.header-links');
+        const isOpen = links.classList.toggle('open');
+        btn.setAttribute('aria-expanded', isOpen);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/sdk/index.html
+++ b/sdk/index.html
@@ -613,6 +613,10 @@ net.set_memory_mode(memory_mode)</code></pre>
     <div class="article-title">ailia SDK を Rust から使用する</div>
     <div class="article-source">tech.ailia.ai</div>
   </a>
+  <a class="article-card" href="../setup/woa/">
+    <div class="article-title">Windows on Arm セットアップガイド</div>
+    <div class="article-source">docs.ailia.ai</div>
+  </a>
   </div>
 </section>
 <!-- /Related Articles -->

--- a/setup/woa/index.html
+++ b/setup/woa/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5Q579RMM');</script>
+<!-- End Google Tag Manager -->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Windows on Arm セットアップガイド - ailia SDK</title>
+  <meta name="description" content="Windows on Arm (WoA) 環境で Python、OpenCV、numpy、ailia SDK をセットアップする手順を解説します。">
+  <link rel="canonical" href="https://docs.ailia.ai/setup/woa/">
+  <link rel="alternate" hreflang="en" href="https://docs.ailia.ai/en/setup/woa/">
+  <link rel="alternate" hreflang="ja" href="https://docs.ailia.ai/setup/woa/">
+  <link rel="alternate" hreflang="x-default" href="https://docs.ailia.ai/en/setup/woa/">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="ja_JP">
+  <meta property="og:locale:alternate" content="en_US">
+  <meta property="og:site_name" content="ailia Documentation">
+  <meta property="og:url" content="https://docs.ailia.ai/setup/woa/">
+  <meta property="og:title" content="Windows on Arm セットアップガイド - ailia SDK">
+  <meta property="og:description" content="Windows on Arm (WoA) 環境で Python、OpenCV、numpy、ailia SDK をセットアップする手順を解説します。">
+  <meta property="og:image" content="https://docs.ailia.ai/ailia_logo.png">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Windows on Arm セットアップガイド - ailia SDK">
+  <meta name="twitter:description" content="Windows on Arm (WoA) 環境で Python、OpenCV、numpy、ailia SDK をセットアップする手順を解説します。">
+  <meta name="twitter:image" content="https://docs.ailia.ai/ailia_logo.png">
+  <link rel="icon" type="image/png" href="../../favicon.png">
+  <link rel="stylesheet" href="../../css/common.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+</head>
+<body>
+  <header>
+    <div class="header-inner">
+      <div class="logo">
+        <a href="https://docs.ailia.ai/" class="logo-icon"><img src="../../ailia_logo.png" alt="ailia"></a>
+        <a href="../../" class="logo-text">ailia SDK Docs</a>
+      </div>
+      <button class="menu-toggle" aria-label="メニューを開く" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+      </button>
+      <div class="header-links">
+        <a href="../../">Top</a>
+        <a href="../../sdk/">SDK</a>
+        <a href="../../tflite/">TFLite</a>
+        <a href="../../llm/">LLM</a>
+        <a href="../../speech/">Speech</a>
+        <a href="../../voice/">Voice</a>
+        <a href="../../tokenizer/">Tokenizer</a>
+        <a href="../../tracker/">Tracker</a>
+        <a href="../../en/setup/woa/" hreflang="en" lang="en">EN</a>
+      </div>
+    </div>
+  </header>
+
+  <section class="hero">
+    <h1>Windows on Arm セットアップガイド</h1>
+    <p>Windows on Arm (WoA) 環境で Python、OpenCV、numpy、ailia SDK をセットアップする手順を説明します。</p>
+  </section>
+
+  <div class="guide-content">
+
+    <h2>概要</h2>
+    <p>Windows on Arm (WoA) は、Arm プロセッサ上で動作する Windows 環境です。Snapdragon X Elite などの Arm ベースのプロセッサを搭載した PC で、ailia SDK を使用するためのセットアップ手順を説明します。</p>
+
+    <h2>Python のインストール</h2>
+    <p>Windows on Arm 環境では、Arm ネイティブ版の Python をインストールする必要があります。以下の Arm 公式ガイドに従ってインストールしてください。</p>
+    <p><a href="https://learn.arm.com/install-guides/py-woa/" target="_blank">https://learn.arm.com/install-guides/py-woa/</a></p>
+
+    <div class="note">
+      <strong>注意:</strong> x86 版の Python ではなく、必ず Arm ネイティブ版の Python をインストールしてください。Arm ネイティブ版を使用することで、最適なパフォーマンスが得られます。
+    </div>
+
+    <h2>numpy のインストール</h2>
+    <p>numpy は pip でインストールできます。</p>
+    <pre><code class="language-bash">pip3 install numpy</code></pre>
+    <p>numpy 2.4.6 がインストールされます。</p>
+
+    <h2>OpenCV のインストール</h2>
+    <p>Windows on Arm 環境では、OpenCV Headless をインストールします。以下のコマンドを実行してください。</p>
+    <pre><code class="language-bash">python -m pip install opencv_python_headless-4.10.0.84-cp313-cp313-win_arm64.whl</code></pre>
+
+    <div class="note">
+      <strong>注意:</strong> OpenCV Headless は GUI 機能を含まないバージョンです。<code>cv2.imshow()</code> などの GUI 表示機能は使用できません。画像の表示が必要な場合は、<code>cv2.imwrite()</code> でファイルに保存するか、他のライブラリを使用してください。
+    </div>
+
+    <h2>ailia SDK のインストール</h2>
+    <p>ailia SDK 1.7 以降では、pip でインストールできます。</p>
+    <pre><code class="language-bash">pip3 install ailia</code></pre>
+
+  </div>
+
+  <footer>
+    <p><a href="https://ailia.ai/" target="_blank">ailia Inc.</a></p>
+    <p class="footer-copy">&copy; ailia Inc. All rights reserved.</p>
+  </footer>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <script>hljs.highlightAll();</script>
+  <script>
+    document.querySelectorAll('.menu-toggle').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const links = btn.parentElement.querySelector('.header-links');
+        const isOpen = links.classList.toggle('open');
+        btn.setAttribute('aria-expanded', isOpen);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -161,4 +161,20 @@
     <xhtml:link rel="alternate" hreflang="ja" href="https://docs.ailia.ai/setup/vulkan/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://docs.ailia.ai/en/setup/vulkan/"/>
   </url>
+  <url>
+    <loc>https://docs.ailia.ai/setup/woa/</loc>
+    <lastmod>2026-05-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://docs.ailia.ai/setup/woa/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://docs.ailia.ai/en/setup/woa/"/>
+  </url>
+  <url>
+    <loc>https://docs.ailia.ai/en/setup/woa/</loc>
+    <lastmod>2026-05-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://docs.ailia.ai/setup/woa/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://docs.ailia.ai/en/setup/woa/"/>
+  </url>
 </urlset>


### PR DESCRIPTION
Add setup pages (JA/EN) covering Python, numpy, OpenCV Headless, and ailia SDK installation on Windows on Arm. Link from SDK Related Articles and add sitemap entries.