### PR TITLE
Add Python setup link and Windows python note to product install

### DIFF
--- a/en/llm/index.html
+++ b/en/llm/index.html
@@ -82,6 +82,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h3>Install</h3>
             <p>Install the ailia LLM Python package from PyPI.</p>
             <pre><code class="language-bash">pip3 install ailia_llm</code></pre>
+            <p>Haven't installed Python or git yet? Start with <a href="../setup/python/">Setting up your Python environment (Windows / Mac / Linux)</a>.</p>
             <a href="https://pypi.org/project/ailia-llm/" target="_blank" class="card-link">View on PyPI</a>
           </div>
           <div class="step">
@@ -90,6 +91,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p>Download <code>example_ailia_llm.py</code> from <code>ailia-models</code> and run it. The script downloads the Gemma 3 4B GGUF file on first run and streams a chat completion. For a multimodal (vision) variant, fetch <code>example_ailia_llm_mtmd.py</code> from the same folder instead.</p>
             <pre><code class="language-bash">wget https://raw.githubusercontent.com/ailia-ai/ailia-models/master/large_language_model/gemma3/example_ailia_llm.py
 python3 example_ailia_llm.py</code></pre>
+            <p>On Windows, use <code>python</code> instead of <code>python3</code>.</p>
             <a href="https://github.com/ailia-ai/ailia-models/blob/master/large_language_model/gemma3/example_ailia_llm.py" target="_blank" class="card-link">example_ailia_llm.py</a>
             <a href="https://github.com/ailia-ai/ailia-models/blob/master/large_language_model/gemma3/example_ailia_llm_mtmd.py" target="_blank" class="card-link">example_ailia_llm_mtmd.py (multimodal)</a>
           </div>

--- a/en/speech/index.html
+++ b/en/speech/index.html
@@ -83,6 +83,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h3>Install</h3>
             <p>Install the ailia Speech Python package and the <code>librosa</code> audio loader used by the sample.</p>
             <pre><code class="language-bash">pip3 install ailia_speech librosa</code></pre>
+            <p>Haven't installed Python or git yet? Start with <a href="../setup/python/">Setting up your Python environment (Windows / Mac / Linux)</a>.</p>
             <a href="https://pypi.org/project/ailia-speech/" target="_blank" class="card-link">View on PyPI</a>
           </div>
           <div class="step">
@@ -92,6 +93,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <pre><code class="language-bash">wget https://raw.githubusercontent.com/ailia-ai/ailia-models/master/audio_processing/whisper/example_ailia_speech.py
 wget -O ax.wav https://raw.githubusercontent.com/ailia-ai/ailia-models/master/audio_processing/whisper/demo.wav
 python3 example_ailia_speech.py</code></pre>
+            <p>On Windows, use <code>python</code> instead of <code>python3</code>.</p>
             <a href="https://github.com/ailia-ai/ailia-models/blob/master/audio_processing/whisper/example_ailia_speech.py" target="_blank" class="card-link">example_ailia_speech.py</a>
           </div>
         </div>

--- a/en/tflite/index.html
+++ b/en/tflite/index.html
@@ -82,6 +82,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h3>Install</h3>
             <p>Install the ailia TFLite Python package from PyPI.</p>
             <pre><code class="language-bash">pip3 install ailia_tflite</code></pre>
+            <p>Haven't installed Python or git yet? Start with <a href="../setup/python/">Setting up your Python environment (Windows / Mac / Linux)</a>.</p>
             <a href="https://pypi.org/project/ailia-tflite/" target="_blank" class="card-link">View on PyPI</a>
           </div>
           <div class="step">
@@ -93,6 +94,7 @@ cd ailia-models-tflite
 pip3 install -r requirements.txt
 cd object_detection/yolox
 python3 yolox.py -v 0</code></pre>
+            <p>On Windows, use <code>python</code> instead of <code>python3</code>.</p>
             <a href="https://github.com/ailia-ai/ailia-models-tflite" target="_blank" class="card-link">Sample Repository</a>
           </div>
         </div>

--- a/en/tokenizer/index.html
+++ b/en/tokenizer/index.html
@@ -83,6 +83,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h3>Install</h3>
             <p>Install the ailia Tokenizer Python package from PyPI.</p>
             <pre><code class="language-bash">pip3 install ailia_tokenizer</code></pre>
+            <p>Haven't installed Python or git yet? Start with <a href="../setup/python/">Setting up your Python environment (Windows / Mac / Linux)</a>.</p>
             <a href="https://pypi.org/project/ailia-tokenizer/" target="_blank" class="card-link">View on PyPI</a>
           </div>
           <div class="step">
@@ -93,6 +94,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 cd ailia-models/natural_language_processing/multilingual-minilmv2
 pip3 install -r requirements.txt
 python3 multilingual-minilmv2.py</code></pre>
+            <p>On Windows, use <code>python</code> instead of <code>python3</code>.</p>
             <a href="https://github.com/ailia-ai/ailia-models/tree/master/natural_language_processing/multilingual-minilmv2/tokenizer" target="_blank" class="card-link">tokenizer/ file layout</a>
           </div>
         </div>

--- a/en/voice/index.html
+++ b/en/voice/index.html
@@ -83,6 +83,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h3>Install</h3>
             <p>Install the ailia Voice Python package together with the <code>librosa</code> and <code>soundfile</code> helpers used by the sample.</p>
             <pre><code class="language-bash">pip3 install ailia_voice librosa soundfile</code></pre>
+            <p>Haven't installed Python or git yet? Start with <a href="../setup/python/">Setting up your Python environment (Windows / Mac / Linux)</a>.</p>
             <a href="https://pypi.org/project/ailia-voice/" target="_blank" class="card-link">View on PyPI</a>
           </div>
           <div class="step">
@@ -91,6 +92,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p>Download <code>example_ailia_voice.py</code> from <code>ailia-models</code> and run it. It clones a target voice from a short reference clip and writes <code>output.wav</code>. Models are downloaded into <code>./models/</code> automatically.</p>
             <pre><code class="language-bash">wget https://raw.githubusercontent.com/ailia-ai/ailia-models/master/audio_processing/gpt-sovits/example_ailia_voice.py
 python3 example_ailia_voice.py</code></pre>
+            <p>On Windows, use <code>python</code> instead of <code>python3</code>.</p>
             <a href="https://github.com/ailia-ai/ailia-models/blob/master/audio_processing/gpt-sovits/example_ailia_voice.py" target="_blank" class="card-link">example_ailia_voice.py</a>
           </div>
         </div>

--- a/llm/index.html
+++ b/llm/index.html
@@ -82,6 +82,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h3>インストール</h3>
             <p>ailia LLM の Python パッケージを PyPI からインストールします。</p>
             <pre><code class="language-bash">pip3 install ailia_llm</code></pre>
+            <p>Python や git をまだインストールしていない方は、<a href="../setup/python/">Python 環境のセットアップ（Windows / Mac / Linux）</a> を先にご覧ください。</p>
             <a href="https://pypi.org/project/ailia-llm/" target="_blank" class="card-link">PyPI で見る</a>
           </div>
           <div class="step">
@@ -90,6 +91,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p><code>ailia-models</code> から <code>example_ailia_llm.py</code> をダウンロードして実行します。初回実行時に Gemma 3 4B の GGUF ファイルをダウンロードし、チャット応答をストリーミング生成します。マルチモーダル (画像対応) 版を試すには同じフォルダの <code>example_ailia_llm_mtmd.py</code> を取得してください。</p>
             <pre><code class="language-bash">wget https://raw.githubusercontent.com/ailia-ai/ailia-models/master/large_language_model/gemma3/example_ailia_llm.py
 python3 example_ailia_llm.py</code></pre>
+            <p>Windows の場合は <code>python3</code> の代わりに <code>python</code> を使用してください。</p>
             <a href="https://github.com/ailia-ai/ailia-models/blob/master/large_language_model/gemma3/example_ailia_llm.py" target="_blank" class="card-link">example_ailia_llm.py</a>
             <a href="https://github.com/ailia-ai/ailia-models/blob/master/large_language_model/gemma3/example_ailia_llm_mtmd.py" target="_blank" class="card-link">example_ailia_llm_mtmd.py (multimodal)</a>
           </div>

--- a/speech/index.html
+++ b/speech/index.html
@@ -83,6 +83,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h3>インストール</h3>
             <p>ailia Speech と、サンプルで使う音声読み込みライブラリ <code>librosa</code> をインストールします。</p>
             <pre><code class="language-bash">pip3 install ailia_speech librosa</code></pre>
+            <p>Python や git をまだインストールしていない方は、<a href="../setup/python/">Python 環境のセットアップ（Windows / Mac / Linux）</a> を先にご覧ください。</p>
             <a href="https://pypi.org/project/ailia-speech/" target="_blank" class="card-link">PyPI で見る</a>
           </div>
           <div class="step">
@@ -92,6 +93,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <pre><code class="language-bash">wget https://raw.githubusercontent.com/ailia-ai/ailia-models/master/audio_processing/whisper/example_ailia_speech.py
 wget -O ax.wav https://raw.githubusercontent.com/ailia-ai/ailia-models/master/audio_processing/whisper/demo.wav
 python3 example_ailia_speech.py</code></pre>
+            <p>Windows の場合は <code>python3</code> の代わりに <code>python</code> を使用してください。</p>
             <a href="https://github.com/ailia-ai/ailia-models/blob/master/audio_processing/whisper/example_ailia_speech.py" target="_blank" class="card-link">example_ailia_speech.py</a>
           </div>
         </div>

--- a/tflite/index.html
+++ b/tflite/index.html
@@ -82,6 +82,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h3>インストール</h3>
             <p>ailia TFLite の Python パッケージを PyPI からインストールします。</p>
             <pre><code class="language-bash">pip3 install ailia_tflite</code></pre>
+            <p>Python や git をまだインストールしていない方は、<a href="../setup/python/">Python 環境のセットアップ（Windows / Mac / Linux）</a> を先にご覧ください。</p>
             <a href="https://pypi.org/project/ailia-tflite/" target="_blank" class="card-link">PyPI で見る</a>
           </div>
           <div class="step">
@@ -93,6 +94,7 @@ cd ailia-models-tflite
 pip3 install -r requirements.txt
 cd object_detection/yolox
 python3 yolox.py -v 0</code></pre>
+            <p>Windows の場合は <code>python3</code> の代わりに <code>python</code> を使用してください。</p>
             <a href="https://github.com/ailia-ai/ailia-models-tflite" target="_blank" class="card-link">サンプルリポジトリ</a>
           </div>
         </div>

--- a/tokenizer/index.html
+++ b/tokenizer/index.html
@@ -83,6 +83,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h3>インストール</h3>
             <p>ailia Tokenizer の Python パッケージを PyPI からインストールします。</p>
             <pre><code class="language-bash">pip3 install ailia_tokenizer</code></pre>
+            <p>Python や git をまだインストールしていない方は、<a href="../setup/python/">Python 環境のセットアップ（Windows / Mac / Linux）</a> を先にご覧ください。</p>
             <a href="https://pypi.org/project/ailia-tokenizer/" target="_blank" class="card-link">PyPI で見る</a>
           </div>
           <div class="step">
@@ -93,6 +94,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 cd ailia-models/natural_language_processing/multilingual-minilmv2
 pip3 install -r requirements.txt
 python3 multilingual-minilmv2.py</code></pre>
+            <p>Windows の場合は <code>python3</code> の代わりに <code>python</code> を使用してください。</p>
             <a href="https://github.com/ailia-ai/ailia-models/tree/master/natural_language_processing/multilingual-minilmv2/tokenizer" target="_blank" class="card-link">tokenizer/ file layout</a>
           </div>
         </div>

--- a/voice/index.html
+++ b/voice/index.html
@@ -83,6 +83,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h3>インストール</h3>
             <p>ailia Voice と、サンプルで使う <code>librosa</code> / <code>soundfile</code> をインストールします。</p>
             <pre><code class="language-bash">pip3 install ailia_voice librosa soundfile</code></pre>
+            <p>Python や git をまだインストールしていない方は、<a href="../setup/python/">Python 環境のセットアップ（Windows / Mac / Linux）</a> を先にご覧ください。</p>
             <a href="https://pypi.org/project/ailia-voice/" target="_blank" class="card-link">PyPI で見る</a>
           </div>
           <div class="step">
@@ -91,6 +92,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p><code>ailia-models</code> から <code>example_ailia_voice.py</code> をダウンロードして実行します。短いリファレンス音声から声をクローンし、<code>output.wav</code> を書き出します。モデルは <code>./models/</code> に自動ダウンロードされます。</p>
             <pre><code class="language-bash">wget https://raw.githubusercontent.com/ailia-ai/ailia-models/master/audio_processing/gpt-sovits/example_ailia_voice.py
 python3 example_ailia_voice.py</code></pre>
+            <p>Windows の場合は <code>python3</code> の代わりに <code>python</code> を使用してください。</p>
             <a href="https://github.com/ailia-ai/ailia-models/blob/master/audio_processing/gpt-sovits/example_ailia_voice.py" target="_blank" class="card-link">example_ailia_voice.py</a>
           </div>
         </div>


### PR DESCRIPTION
Mirror the SDK index additions on the Speech, Voice, Tokenizer, TFLite, and LLM pages (JA + EN): link to the Python environment setup guide under the install step, and note that Windows users run python instead of python3 under the sample run step.