### PR TITLE
Add binding links to speech docs, fix README binding/JNI links

### DIFF
--- a/en/speech/index.html
+++ b/en/speech/index.html
@@ -493,6 +493,7 @@ speech.close()</code></pre>
         <h3>C++</h3>
         <ul>
           <li><a href="../../speech/cpp/en/">API</a></li>
+          <li><a href="https://github.com/ailia-ai/ailia-speech-cpp" target="_blank">Binding</a></li>
         </ul>
       </div>
 
@@ -500,6 +501,7 @@ speech.close()</code></pre>
         <h3>Unity</h3>
         <ul>
           <li><a href="../../speech/unity/en/">API</a></li>
+          <li><a href="https://github.com/ailia-ai/ailia-speech-unity" target="_blank">Binding</a></li>
         </ul>
       </div>
 
@@ -507,6 +509,7 @@ speech.close()</code></pre>
         <h3>Flutter</h3>
         <ul>
           <li><a href="../../speech/flutter/en/">API</a></li>
+          <li><a href="https://github.com/ailia-ai/ailia-speech-flutter" target="_blank">Binding</a></li>
         </ul>
       </div>
 

--- a/speech/README.md
+++ b/speech/README.md
@@ -7,4 +7,5 @@ ailia Speech is a library for speech recognition. It uses ailia SDK and ailia.au
 - [Python API (EN)](https://ailia-ai.github.io/ailia-sdk/supplemental/speech/python/en/)
 - [Python Example (EN) (PyPI)](https://pypi.org/project/ailia-speech/)
 - [Flutter API (EN)](https://ailia-ai.github.io/ailia-sdk/supplemental/speech/flutter/en/)
-- [Binding (CPP)](https://github.com/ailia-ai/ailia-tokenizer-cpp) [(Unity)](https://github.com/ailia-ai/ailia-tokenizer-unity) [(Flutter)](https://github.com/ailia-ai/ailia-tokenizer-flutter) [(JNI)](https://github.com/ailia-ai/ailia-tokenizer-jni)
+- [JNI API (EN)](https://ailia-ai.github.io/ailia-sdk/supplemental/speech/java/en/)
+- [Binding (CPP)](https://github.com/ailia-ai/ailia-speech-cpp) [(Unity)](https://github.com/ailia-ai/ailia-speech-unity) [(Flutter)](https://github.com/ailia-ai/ailia-speech-flutter) [(JNI)](https://github.com/ailia-ai/ailia-speech-jni)

--- a/speech/index.html
+++ b/speech/index.html
@@ -493,6 +493,7 @@ speech.close()</code></pre>
         <h3>C++</h3>
         <ul>
           <li><a href="../speech/cpp/jp/">API</a></li>
+          <li><a href="https://github.com/ailia-ai/ailia-speech-cpp" target="_blank">Binding</a></li>
         </ul>
       </div>
 
@@ -500,6 +501,7 @@ speech.close()</code></pre>
         <h3>Unity</h3>
         <ul>
           <li><a href="../speech/unity/jp/">API</a></li>
+          <li><a href="https://github.com/ailia-ai/ailia-speech-unity" target="_blank">Binding</a></li>
         </ul>
       </div>
 
@@ -507,6 +509,7 @@ speech.close()</code></pre>
         <h3>Flutter</h3>
         <ul>
           <li><a href="../speech/flutter/en/">API (EN)</a></li>
+          <li><a href="https://github.com/ailia-ai/ailia-speech-flutter" target="_blank">Binding</a></li>
         </ul>
       </div>
 

--- a/tokenizer/README.md
+++ b/tokenizer/README.md
@@ -7,4 +7,5 @@ ailia Tokenizer is a library for encode NLP text and decode NLP tokens. ailia To
 - [Python API (EN)](https://ailia-ai.github.io/ailia-sdk/supplemental/tokenizer/python/en/)
 - [Python Example (EN) (PyPI)](https://pypi.org/project/ailia-tokenizer/)
 - [Flutter API (EN)](https://ailia-ai.github.io/ailia-sdk/supplemental/tokenizer/flutter/en/)
+- [JNI API (EN)](https://ailia-ai.github.io/ailia-sdk/supplemental/tokenizer/java/en/)
 - [Binding (CPP)](https://github.com/ailia-ai/ailia-tokenizer-cpp) [(Unity)](https://github.com/ailia-ai/ailia-tokenizer-unity) [(Flutter)](https://github.com/ailia-ai/ailia-tokenizer-flutter) [(JNI)](https://github.com/ailia-ai/ailia-tokenizer-jni)


### PR DESCRIPTION
- Add C++/Unity/Flutter binding links to speech index.html (JP/EN), matching voice's card layout
- Fix speech/README.md Binding line pointing to ailia-tokenizer-* repos instead of ailia-speech-*
- Add missing JNI API links to speech/README.md and tokenizer/README.md