### PR TITLE
Update Python and Flutter Examples

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -363,6 +363,7 @@ footer a:hover {
 }
 
 .section-subtitle { font-size: 16px; color: var(--text-light); margin-top: -20px; margin-bottom: 32px; }
+.code-block + .section-subtitle { margin-top: 32px; }
 .steps-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 20px; }
 .step { background: var(--bg); border-radius: var(--radius); padding: 28px; border: 1px solid var(--border); position: relative; display: flex; flex-direction: column; min-width: 0; transition: box-shadow 0.25s, transform 0.25s; }
 .step:hover { box-shadow: var(--shadow); }
@@ -375,6 +376,7 @@ footer a:hover {
 .step .card-link:hover { gap: 10px; }
 .step .card-link::after { content: "\2192"; transition: margin-left 0.2s; }
 .step .card-link + .card-link { margin-top: 6px; }
+.step .card-link + p { margin-top: 14px; }
 
 /* System Requirements */
 .req-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 20px; }

--- a/en/speech/index.html
+++ b/en/speech/index.html
@@ -94,7 +94,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 wget -O ax.wav https://raw.githubusercontent.com/ailia-ai/ailia-models/master/audio_processing/whisper/demo.wav
 python3 example_ailia_speech.py</code></pre>
             <p>On Windows, use <code>python</code> instead of <code>python3</code>.</p>
-            <a href="https://github.com/ailia-ai/ailia-models/blob/master/audio_processing/whisper/example_ailia_speech.py" target="_blank" class="card-link">example_ailia_speech.py</a>
+            <a href="https://github.com/ailia-ai/ailia-models/blob/master/audio_processing/whisper/example_ailia_speech.py" target="_blank" class="card-link">example_ailia_speech.py (Whisper)</a>
+            <p>To use SenseVoice, use the script below instead.</p>
+            <a href="https://github.com/ailia-ai/ailia-models/blob/master/audio_processing/sensevoice/example_ailia_speech.py" target="_blank" class="card-link">example_ailia_speech.py (SenseVoice)</a>
           </div>
         </div>
       </div>
@@ -340,6 +342,12 @@ speech.initialize_model(
     model_type=ailia_speech.AILIA_SPEECH_MODEL_TYPE_WHISPER_MULTILINGUAL_LARGE_V3_TURBO,
 )
 text = speech.transcribe(audio_waveform, sample_rate)</code></pre>
+        <p class="section-subtitle">To perform speaker diarization, pass <code>diarization_type</code> to <code>initialize_model()</code>. The diarization results are stored in <code>speaker_id</code>.</p>
+        <pre class="code-block"><code class="language-python">speech.initialize_model(
+    model_path="./models/",
+    model_type=ailia_speech.AILIA_SPEECH_MODEL_TYPE_WHISPER_MULTILINGUAL_LARGE_V3_TURBO,
+    diarization_type=ailia_speech.AILIA_SPEECH_DIARIZATION_TYPE_PYANNOTE_AUDIO,
+)</code></pre>
       </div>
 
       <div class="platform-panel hidden" data-platform="cpp">

--- a/en/tracker/index.html
+++ b/en/tracker/index.html
@@ -175,13 +175,12 @@ cd object_tracking/bytetrack
           <div class="step">
             <div class="step-number">2</div>
             <h3>Run a Sample</h3>
-            <p>The binding repository ships a ready-to-run <code>example</code> app. It feeds dummy detections every frame so you can watch tracking IDs being assigned on screen.</p>
-            <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-tracker-flutter.git
-cd ailia-tracker-flutter/example
+            <p>A sample app for object tracking with ByteTrack is available in the Flutter sample repository. Clone it and run it as-is.</p>
+            <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-models-flutter.git
+cd ailia-models-flutter
 flutter pub get
 flutter run</code></pre>
-            <a href="https://github.com/ailia-ai/ailia-tracker-flutter" target="_blank" class="card-link">Binding</a>
-            <a href="https://github.com/ailia-ai/ailia-tracker-flutter/blob/main/example/lib/main.dart" target="_blank" class="card-link">main.dart</a>
+            <a href="https://github.com/ailia-ai/ailia-models-flutter" target="_blank" class="card-link">Sample Repository</a>
           </div>
         </div>
       </div>

--- a/en/voice/index.html
+++ b/en/voice/index.html
@@ -93,7 +93,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <pre><code class="language-bash">wget https://raw.githubusercontent.com/ailia-ai/ailia-models/master/audio_processing/gpt-sovits/example_ailia_voice.py
 python3 example_ailia_voice.py</code></pre>
             <p>On Windows, use <code>python</code> instead of <code>python3</code>.</p>
-            <a href="https://github.com/ailia-ai/ailia-models/blob/master/audio_processing/gpt-sovits/example_ailia_voice.py" target="_blank" class="card-link">example_ailia_voice.py</a>
+            <a href="https://github.com/ailia-ai/ailia-models/blob/master/audio_processing/gpt-sovits/example_ailia_voice.py" target="_blank" class="card-link">example_ailia_voice.py (GPT-SoVITS)</a>
+            <p>To use the distilled model (GPT-SoVITS v2 Pro), use the script below instead.</p>
+            <a href="https://github.com/ailia-ai/ailia-models/blob/master/audio_processing/gpt-sovits-v2-pro/example_ailia_voice.py" target="_blank" class="card-link">example_ailia_voice.py (GPT-SoVITS v2 Pro)</a>
           </div>
         </div>
       </div>
@@ -339,6 +341,9 @@ voice.set_reference_audio(
     ref_text, ailia_voice.AILIA_VOICE_G2P_TYPE_GPT_SOVITS_JA, ref_audio, rate,
 )
 buf, sr = voice.synthesize_voice("こんにちは。", ailia_voice.AILIA_VOICE_G2P_TYPE_GPT_SOVITS_JA)</code></pre>
+        <p class="section-subtitle">To synthesize speech in English or Chinese, switch the G2P type.</p>
+        <pre class="code-block"><code class="language-python">buf, sr = voice.synthesize_voice("Hello world.", ailia_voice.AILIA_VOICE_G2P_TYPE_GPT_SOVITS_EN)
+buf, sr = voice.synthesize_voice("你好。今天天气真好。", ailia_voice.AILIA_VOICE_G2P_TYPE_GPT_SOVITS_ZH)</code></pre>
       </div>
 
       <div class="platform-panel hidden" data-platform="cpp">

--- a/speech/index.html
+++ b/speech/index.html
@@ -94,7 +94,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 wget -O ax.wav https://raw.githubusercontent.com/ailia-ai/ailia-models/master/audio_processing/whisper/demo.wav
 python3 example_ailia_speech.py</code></pre>
             <p>Windows の場合は <code>python3</code> の代わりに <code>python</code> を使用してください。</p>
-            <a href="https://github.com/ailia-ai/ailia-models/blob/master/audio_processing/whisper/example_ailia_speech.py" target="_blank" class="card-link">example_ailia_speech.py</a>
+            <a href="https://github.com/ailia-ai/ailia-models/blob/master/audio_processing/whisper/example_ailia_speech.py" target="_blank" class="card-link">example_ailia_speech.py (Whisper)</a>
+            <p>SenseVoice を使用する場合は下記のスクリプトを使用してください。</p>
+            <a href="https://github.com/ailia-ai/ailia-models/blob/master/audio_processing/sensevoice/example_ailia_speech.py" target="_blank" class="card-link">example_ailia_speech.py (SenseVoice)</a>
           </div>
         </div>
       </div>
@@ -340,6 +342,12 @@ speech.initialize_model(
     model_type=ailia_speech.AILIA_SPEECH_MODEL_TYPE_WHISPER_MULTILINGUAL_LARGE_V3_TURBO,
 )
 text = speech.transcribe(audio_waveform, sample_rate)</code></pre>
+        <p class="section-subtitle">話者分離 (ダイアリゼーション) を行う場合は、<code>initialize_model()</code> に <code>diarization_type</code> を指定します。話者分離の結果は <code>speaker_id</code> に格納されます。</p>
+        <pre class="code-block"><code class="language-python">speech.initialize_model(
+    model_path="./models/",
+    model_type=ailia_speech.AILIA_SPEECH_MODEL_TYPE_WHISPER_MULTILINGUAL_LARGE_V3_TURBO,
+    diarization_type=ailia_speech.AILIA_SPEECH_DIARIZATION_TYPE_PYANNOTE_AUDIO,
+)</code></pre>
       </div>
 
       <div class="platform-panel hidden" data-platform="cpp">

--- a/tracker/index.html
+++ b/tracker/index.html
@@ -175,13 +175,12 @@ cd object_tracking/bytetrack
           <div class="step">
             <div class="step-number">2</div>
             <h3>サンプルを実行</h3>
-            <p>バインディングリポジトリの <code>example</code> アプリをそのまま実行できます。ダミーの検出結果を毎フレーム与えて、追跡 ID の割り当てを画面上で確認できます。</p>
-            <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-tracker-flutter.git
-cd ailia-tracker-flutter/example
+            <p>ByteTrack による物体追跡のサンプルアプリは Flutter サンプルリポジトリにあります。クローンしてそのまま実行できます。</p>
+            <pre><code class="language-bash">git clone https://github.com/ailia-ai/ailia-models-flutter.git
+cd ailia-models-flutter
 flutter pub get
 flutter run</code></pre>
-            <a href="https://github.com/ailia-ai/ailia-tracker-flutter" target="_blank" class="card-link">バインディング</a>
-            <a href="https://github.com/ailia-ai/ailia-tracker-flutter/blob/main/example/lib/main.dart" target="_blank" class="card-link">main.dart</a>
+            <a href="https://github.com/ailia-ai/ailia-models-flutter" target="_blank" class="card-link">サンプルリポジトリ</a>
           </div>
         </div>
       </div>

--- a/voice/index.html
+++ b/voice/index.html
@@ -93,7 +93,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <pre><code class="language-bash">wget https://raw.githubusercontent.com/ailia-ai/ailia-models/master/audio_processing/gpt-sovits/example_ailia_voice.py
 python3 example_ailia_voice.py</code></pre>
             <p>Windows の場合は <code>python3</code> の代わりに <code>python</code> を使用してください。</p>
-            <a href="https://github.com/ailia-ai/ailia-models/blob/master/audio_processing/gpt-sovits/example_ailia_voice.py" target="_blank" class="card-link">example_ailia_voice.py</a>
+            <a href="https://github.com/ailia-ai/ailia-models/blob/master/audio_processing/gpt-sovits/example_ailia_voice.py" target="_blank" class="card-link">example_ailia_voice.py (GPT-SoVITS)</a>
+            <p>蒸留モデル (GPT-SoVITS v2 Pro) を使用する場合は下記のスクリプトを使用してください。</p>
+            <a href="https://github.com/ailia-ai/ailia-models/blob/master/audio_processing/gpt-sovits-v2-pro/example_ailia_voice.py" target="_blank" class="card-link">example_ailia_voice.py (GPT-SoVITS v2 Pro)</a>
           </div>
         </div>
       </div>
@@ -339,6 +341,9 @@ voice.set_reference_audio(
     ref_text, ailia_voice.AILIA_VOICE_G2P_TYPE_GPT_SOVITS_JA, ref_audio, rate,
 )
 buf, sr = voice.synthesize_voice("こんにちは。", ailia_voice.AILIA_VOICE_G2P_TYPE_GPT_SOVITS_JA)</code></pre>
+        <p class="section-subtitle">英語や中国語で音声合成する場合は、G2P タイプを切り替えます。</p>
+        <pre class="code-block"><code class="language-python">buf, sr = voice.synthesize_voice("Hello world.", ailia_voice.AILIA_VOICE_G2P_TYPE_GPT_SOVITS_EN)
+buf, sr = voice.synthesize_voice("你好。今天天气真好。", ailia_voice.AILIA_VOICE_G2P_TYPE_GPT_SOVITS_ZH)</code></pre>
       </div>
 
       <div class="platform-panel hidden" data-platform="cpp">


### PR DESCRIPTION
- Speech (JP/EN): link to the SenseVoice sample script in the Run a Sample step, and add a speaker diarization example to the Python API section
- Voice (JP/EN): link to the distilled model (GPT-SoVITS v2 Pro) sample script in the Run a Sample step, and add English/Chinese synthesis examples to the Python API section
- Tracker (JP/EN): point the Flutter sample to ailia-models-flutter like the other libraries
- CSS: add spacing before a paragraph that follows a card-link and before a section-subtitle that follows a code block