### PR TITLE
Add ailia MotionPortrait docs and unify site structure

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -55,6 +55,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     .card-icon.llm       { background: #f3e8ff; color: #7c3aed; }
     .card-icon.tracker   { background: #e0f2fe; color: #0284c7; }
     .card-icon.tflite    { background: #fff7ed; color: #ea580c; }
+    .card-icon.mp        { background: #ffe4e6; color: #e11d48; }
     .card h3 { margin-bottom: 8px; }
     .card p { font-size: 14px; color: var(--text-light); flex: 1; margin-bottom: 16px; }
     .card-platforms { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 16px; }
@@ -92,6 +93,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="tokenizer/">Tokenizer</a>
         <a href="tracker/">Tracker</a>
         <a href="js/">JS</a>
+        <a href="mp/">MP</a>
         <a href="../" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>
@@ -248,6 +250,19 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <span class="platform-tag">WebAssembly</span>
         </div>
         <a href="js/" class="card-link">View Documentation</a>
+      </div>
+
+      <div class="card">
+        <div class="card-icon mp">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+        </div>
+        <h3>ailia MotionPortrait</h3>
+        <p>Avatar library that generates facial expression and lip-sync animation from a single image.</p>
+        <div class="card-platforms">
+          <span class="platform-tag">JavaScript</span>
+          <span class="platform-tag">Unity</span>
+        </div>
+        <a href="mp/" class="card-link">View Documentation</a>
       </div>
 
     </div>

--- a/en/js/index.html
+++ b/en/js/index.html
@@ -52,6 +52,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../tokenizer/">Tokenizer</a>
         <a href="../tracker/">Tracker</a>
         <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
         <a href="../../js/" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>

--- a/en/llm/index.html
+++ b/en/llm/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../voice/">Voice</a>
         <a href="../tokenizer/">Tokenizer</a>
         <a href="../tracker/">Tracker</a>
+        <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
         <a href="../../llm/" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>

--- a/en/mp/index.html
+++ b/en/mp/index.html
@@ -272,7 +272,7 @@ if (mpwebgl.instance.isanimplaying(2)) {
       <h2 class="section-title">Resources</h2>
       <div class="materials-grid">
         <div class="platform-panel" data-platform="javascript">
-          <a href="../../mp/docs/mp_animator_js_manual_en.pdf" target="_blank" class="material-item">
+          <a href="https://ailia.ai/mp/docs/mp_animator_js_manual_en.pdf" target="_blank" class="material-item">
             <div class="material-icon">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>
             </div>
@@ -283,7 +283,7 @@ if (mpwebgl.instance.isanimplaying(2)) {
           </a>
         </div>
         <div class="platform-panel hidden" data-platform="unity">
-          <a href="../../mp/docs/mp_animator_unity_manual_en.pdf" target="_blank" class="material-item">
+          <a href="https://ailia.ai/mp/docs/mp_animator_unity_manual_en.pdf" target="_blank" class="material-item">
             <div class="material-icon">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>
             </div>

--- a/en/mp/index.html
+++ b/en/mp/index.html
@@ -121,17 +121,18 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <div class="step">
             <div class="step-number">1</div>
             <h3>Install</h3>
-            <p>Clone the sample program <code>mp-sample-kotlin</code>, initialize its submodules, and open it in Android Studio. The SDK <code>mp-sdk-kotlin</code> is included as a submodule within the <code>mp-sample-kotlin</code> project.</p>
+            <p>Clone the sample program <code>mp-sample-kotlin</code> and initialize its submodules. The SDK <code>mp-sdk-kotlin</code> is included as a submodule within the <code>mp-sample-kotlin</code> project.</p>
             <pre><code class="language-bash">git clone https://github.com/ailia-ai/mp-sample-kotlin.git
 cd mp-sample-kotlin
 git submodule update --init --recursive</code></pre>
             <a href="https://github.com/ailia-ai/mp-sample-kotlin" target="_blank" class="card-link">Sample Repository</a>
             <a href="https://github.com/ailia-ai/mp-sdk-kotlin" target="_blank" class="card-link">SDK</a>
+            <a href="https://github.com/ailia-ai/mp-sample-kotlin/blob/main/TUTORIAL.md" target="_blank" class="card-link">Tutorial</a>
           </div>
           <div class="step">
             <div class="step-number">2</div>
             <h3>Run</h3>
-            <p>Connect an Android device over USB or start an emulator, then run the sample program with the Run button in Android Studio.</p>
+            <p>Open <code>mp-sample-kotlin</code> in Android Studio Narwhal 3 Feature Drop (2025.1.3) or later, connect an Android device over USB, and build, install, and run the sample with the Run button.</p>
           </div>
         </div>
       </div>
@@ -170,8 +171,8 @@ git submodule update --init --recursive</code></pre>
         <div class="req-card">
           <h3>Kotlin</h3>
           <ul>
-            <li>Android 7.1 (API 25) or later</li>
-            <li>Android Studio 2025.1.3 or later</li>
+            <li>Android 7.0 (API 24) or later</li>
+            <li>Android Studio Narwhal 3 Feature Drop (2025.1.3) or later</li>
             <li>Kotlin / Java (JNI)</li>
           </ul>
         </div>
@@ -322,6 +323,17 @@ if (mpwebgl.instance.isanimplaying(2)) {
             </div>
             <div class="material-text">
               Unity Operation Manual (PDF)
+              <small>Sample program operation manual Ver. 1.0</small>
+            </div>
+          </a>
+        </div>
+        <div class="platform-panel hidden" data-platform="kotlin">
+          <a href="https://ailia.ai/mp/docs/mp_animator_kotlin_manual_en.pdf" target="_blank" class="material-item">
+            <div class="material-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>
+            </div>
+            <div class="material-text">
+              Kotlin Operation Manual (PDF)
               <small>Sample program operation manual Ver. 1.0</small>
             </div>
           </a>

--- a/en/mp/index.html
+++ b/en/mp/index.html
@@ -1,0 +1,354 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5Q579RMM');</script>
+<!-- End Google Tag Manager -->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ailia MotionPortrait - Documentation</title>
+  <meta name="description" content="ailia MotionPortrait - Avatar library that generates facial expression and lip-sync animation from a single image.">
+  <link rel="canonical" href="https://docs.ailia.ai/en/mp/">
+  <link rel="alternate" hreflang="en" href="https://docs.ailia.ai/en/mp/">
+  <link rel="alternate" hreflang="ja" href="https://docs.ailia.ai/mp/">
+  <link rel="alternate" hreflang="x-default" href="https://docs.ailia.ai/en/mp/">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:locale:alternate" content="ja_JP">
+  <meta property="og:site_name" content="ailia Documentation">
+  <meta property="og:url" content="https://docs.ailia.ai/en/mp/">
+  <meta property="og:title" content="ailia MotionPortrait - Documentation">
+  <meta property="og:description" content="ailia MotionPortrait - Avatar library that generates facial expression and lip-sync animation from a single image.">
+  <meta property="og:image" content="https://docs.ailia.ai/ailia_logo.png">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="ailia MotionPortrait - Documentation">
+  <meta name="twitter:description" content="ailia MotionPortrait - Avatar library that generates facial expression and lip-sync animation from a single image.">
+  <meta name="twitter:image" content="https://docs.ailia.ai/ailia_logo.png">
+  <link rel="icon" type="image/png" href="../../favicon.png">
+  <link rel="stylesheet" href="../../css/common.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+</head>
+<body>
+  <header>
+    <div class="header-inner">
+      <div class="logo">
+        <a href="https://docs.ailia.ai/en/" class="logo-icon"><img src="../../ailia_logo.png" alt="ailia"></a>
+        <a href="./" class="logo-text">ailia MotionPortrait Docs</a>
+      </div>
+      <button class="menu-toggle" aria-label="Open menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+      </button>
+      <div class="header-links">
+        <a href="../">Top</a>
+        <a href="../sdk/">SDK</a>
+        <a href="../tflite/">TFLite</a>
+        <a href="../llm/">LLM</a>
+        <a href="../speech/">Speech</a>
+        <a href="../voice/">Voice</a>
+        <a href="../tokenizer/">Tokenizer</a>
+        <a href="../tracker/">Tracker</a>
+        <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
+        <a href="../../mp/" hreflang="ja" lang="ja">JA</a>
+      </div>
+    </div>
+  </header>
+
+  <section class="hero">
+    <h1>ailia MotionPortrait</h1>
+    <p>Try preset avatars, or drag and drop your own image to generate one of your own, complete with facial expression and lip-sync animation.</p>
+  </section>
+
+  <!-- Getting Started -->
+  <section class="getting-started-section">
+    <div class="section">
+      <h2 class="section-title">Getting Started</h2>
+      <p class="section-subtitle">Choose a platform and try your first avatar animation.</p>
+
+      <div class="platform-tabs" role="tablist">
+        <button class="platform-tab active" data-platform="javascript" role="tab">JavaScript</button>
+        <button class="platform-tab" data-platform="unity" role="tab">Unity</button>
+      </div>
+
+      <!-- JavaScript -->
+      <div class="platform-panel" data-platform="javascript">
+        <div class="steps-grid">
+          <div class="step">
+            <div class="step-number">1</div>
+            <h3>Install</h3>
+            <p>Clone the sample program <code>mp-sample-js</code>. The SDK <code>mp-sdk-js</code> is included as a submodule within the <code>mp-sample-js</code> project.</p>
+            <a href="https://github.com/ailia-ai/mp-sample-js" target="_blank" class="card-link">Sample Repository</a>
+            <a href="https://github.com/ailia-ai/mp-sdk-js" target="_blank" class="card-link">SDK</a>
+          </div>
+          <div class="step">
+            <div class="step-number">2</div>
+            <h3>Run</h3>
+            <p>Run the following command in the <code>mp-sample-js</code> folder to start a web server.</p>
+            <pre><code class="language-bash">python3 -m http.server 8000</code></pre>
+            <p>You can run the sample program by accessing <code>http://localhost:8000/mpavatar</code> in your web browser. A port number other than 8000 can also be used.</p>
+            <p>If you haven't installed Python or git yet, please see <a href="../setup/python/">Setting up your Python environment (Windows / Mac / Linux)</a> first.</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Unity -->
+      <div class="platform-panel hidden" data-platform="unity">
+        <div class="steps-grid">
+          <div class="step">
+            <div class="step-number">1</div>
+            <h3>Install</h3>
+            <p>After cloning the sample program <code>mp-sample-unity</code>, open it in Unity 6.3 LTS (6000.3.16f1) or later. The SDK <code>mp-sdk-unity</code> is downloaded automatically via the Package Manager.</p>
+            <a href="https://github.com/ailia-ai/mp-sample-unity" target="_blank" class="card-link">Sample Repository</a>
+            <a href="https://github.com/ailia-ai/mp-sdk-unity" target="_blank" class="card-link">SDK</a>
+          </div>
+          <div class="step">
+            <div class="step-number">2</div>
+            <h3>Run</h3>
+            <p>Open the <code>mpSampleScene.unity</code> scene and press Play. Alternatively, build and run it from the menu bar via [File]-[Build Profiles].</p>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- System Requirements -->
+  <section class="section">
+    <h2 class="section-title">System Requirements</h2>
+    <p class="section-subtitle">ailia MotionPortrait runs in browser and mobile environments.</p>
+    <div class="req-grid">
+      <div class="platform-panel" data-platform="javascript">
+        <div class="req-card">
+          <h3>JavaScript</h3>
+          <ul>
+            <li>A WebGL-capable web browser</li>
+            <li>Run via an HTTP server</li>
+            <li>An environment with internet access</li>
+          </ul>
+        </div>
+      </div>
+      <div class="platform-panel hidden" data-platform="unity">
+        <div class="req-card">
+          <h3>Unity</h3>
+          <ul>
+            <li>Windows 10 (version 21H1 or later) / Windows 11</li>
+            <li>macOS Monterey (12.0) or later</li>
+            <li>Linux (Ubuntu 22.04 / 24.04)</li>
+            <li>iOS 15 or later</li>
+            <li>Android 7.1 (API 25) or later</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+<!--
+  <section class="getting-started-section">
+    <div class="section">
+      <h2 class="section-title">Features</h2>
+      <p class="section-subtitle">Features available in the JavaScript sample program.</p>
+      <div class="req-grid">
+        <div class="req-card">
+          <h3>Avatar Generation</h3>
+          <ul>
+            <li>Switch between preset avatars (6 by default)</li>
+            <li>Generate an avatar from any image file</li>
+          </ul>
+        </div>
+        <div class="req-card">
+          <h3>Accessories</h3>
+          <ul>
+            <li>Hair (5 types) / Glasses (5 types)</li>
+            <li>Beard (4 types) / Contact lenses (3 types)</li>
+            <li>CHANGE to switch, CLEAR to remove</li>
+          </ul>
+        </div>
+        <div class="req-card">
+          <h3>Makeup</h3>
+          <ul>
+            <li>Lip (5 types) / Cheek (6 types) / Eye makeup (6 types)</li>
+            <li>CLEAR removes all makeup</li>
+          </ul>
+        </div>
+        <div class="req-card">
+          <h3>Animation / Expression</h3>
+          <ul>
+            <li>ANIMATION — plays 2 types of animation (preset avatars only)</li>
+            <li>SPEECH — lip-sync with 2 voice options</li>
+            <li>EXPRESSION — switches between 7 expressions</li>
+            <li>Gaze follows the mouse pointer, FPS counter displayed</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+-->
+
+<!--
+  <section class="getting-started-section">
+    <div class="section">
+      <h2 class="section-title">Using the API in Your Project</h2>
+      <p class="section-subtitle">A minimal example for embedding an avatar in your own application. Avatar files (<code>.bin</code>) are loaded by adding them to the file list inside <code>js/mp_fileio.js</code>.</p>
+      <pre class="code-block"><code class="language-javascript">// Start/stop lip-sync with a specified voice file
+var voiceId = mpwebgl.instance.loadvoice('items/voice/voice0.mp3');
+if (mpwebgl.instance.isanimplaying(2)) {
+    mpwebgl.instance.pauseaudio();
+    mpwebgl.instance.unloadanimation();
+    mpwebgl.instance.destroyvoice();
+}</code></pre>
+    </div>
+  </section>
+-->
+
+<!--
+  <section class="section">
+    <h2 class="section-title">Platform-specific API Reference</h2>
+    <div class="card-grid">
+      <div class="card">
+        <h3>JavaScript</h3>
+        <ul>
+          <li><a href="#">API Reference (URL not set)</a></li>
+          <li><a href="#">Sample Repository (URL not set)</a></li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>Unity</h3>
+        <ul>
+          <li>Coming soon</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+-->
+
+<!--
+  <section class="getting-started-section">
+    <div class="section">
+      <h2 class="section-title">FAQ</h2>
+      <p class="section-subtitle">Frequently asked questions about ailia MotionPortrait.</p>
+      <div class="faq-list">
+
+        <details class="faq-item">
+          <summary>What browsers and environments are supported?</summary>
+          <p>It runs on modern WebGL-capable browsers (Chrome, Edge, Safari, etc.). Detailed requirements are being prepared.</p>
+        </details>
+
+        <details class="faq-item">
+          <summary>How do I use my own image as an avatar?</summary>
+          <p>Selecting an image file via the "BROWSE FILE" button in the GUI generates an avatar from that image. As with preset avatars, you can add Hair / Glasses / Beard / Lens and makeup. For more precise feature-point adjustment, use the dedicated avatar generation tool (account required). Use a square image (512×512, 1024×1024, or 2048×2048).</p>
+        </details>
+
+        <details class="faq-item">
+          <summary>Where are the model files used by the sample?</summary>
+          <p>Avatar <code>.bin</code> files are placed in the <code>items/face</code> folder and added to the file list in <code>js/mp_fileio.js</code>.</p>
+        </details>
+
+        <details class="faq-item">
+          <summary>How is the image's alpha channel handled?</summary>
+          <p>If a PNG image has an alpha channel, its value is used as the character's outline. If you use a fully opaque background (alpha value 255), the outline becomes a square. With formats that have no alpha channel, such as JPEG, the outline is automatically estimated. For a higher-precision avatar, include the character's mask values in the alpha channel.</p>
+        </details>
+
+        <details class="faq-item">
+          <summary>How do I specify the avatar's resolution?</summary>
+          <p>You can specify the avatar's resolution with the <code>texsize</code> option. Choose from 512 / 1024 / 2048 (px).</p>
+        </details>
+
+        <details class="faq-item">
+          <summary>Where can I find the installation instructions?</summary>
+          <p>Installation steps are described in the "Getting Started" section of this page. For detailed operation of each button, please refer to the operation manual (PDF) in the "Resources" section.</p>
+        </details>
+
+      </div>
+    </div>
+  </section>
+-->
+
+  <section class="materials-section">
+    <div class="section">
+      <h2 class="section-title">Resources</h2>
+      <div class="materials-grid">
+        <div class="platform-panel" data-platform="javascript">
+          <a href="../../mp/docs/mp_animator_js_manual_en.pdf" target="_blank" class="material-item">
+            <div class="material-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>
+            </div>
+            <div class="material-text">
+              JavaScript Operation Manual (PDF)
+              <small>Sample program operation manual Ver. 1.0</small>
+            </div>
+          </a>
+        </div>
+        <div class="platform-panel hidden" data-platform="unity">
+          <a href="../../mp/docs/mp_animator_unity_manual_en.pdf" target="_blank" class="material-item">
+            <div class="material-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>
+            </div>
+            <div class="material-text">
+              Unity Operation Manual (PDF)
+              <small>Sample program operation manual Ver. 1.0</small>
+            </div>
+          </a>
+        </div>
+        <a href="https://ailia.ai/mp/" target="_blank" class="material-item">
+          <div class="material-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>
+          </div>
+          <div class="material-text">
+            Product Site
+            <small>ailia.ai/mp/</small>
+          </div>
+        </a>
+      </div>
+    </div>
+  </section>
+
+<!-- Related Articles -->
+<section class="section">
+  <h2 class="section-title">Related Articles</h2>
+  <p class="section-subtitle">Model explanations, release notes, and tutorials from the ailia Tech Blog.</p>
+  <div class="articles-grid">
+    <a class="article-card" href="https://medium.com/axinc-ai/motion-portrait-avatar-solution-combined-with-llm-9db0dc187a91" target="_blank" rel="noopener">
+      <div class="article-title">Motion Portrait: Avatar Solution Combined with LLM</div>
+      <div class="article-source">medium.com/axinc-ai</div>
+    </a>
+  </div>
+</section>
+<!-- /Related Articles -->
+
+  <footer>
+    <p><a href="https://ailia.ai/" target="_blank">ailia Inc.</a></p>
+    <p class="footer-copy">&copy; ailia Inc. All rights reserved.</p>
+  </footer>
+
+  <script>
+    document.querySelectorAll('.platform-tabs').forEach(tabsBar => {
+      const tabs = tabsBar.querySelectorAll('.platform-tab');
+      tabs.forEach(tab => {
+        tab.addEventListener('click', () => {
+          const platform = tab.dataset.platform;
+          tabs.forEach(t => t.classList.toggle('active', t === tab));
+          // This page has a single tab bar, but its panels live in several
+          // sections, so every panel on the page follows the selected tab.
+          document.querySelectorAll('.platform-panel').forEach(p => p.classList.toggle('hidden', p.dataset.platform !== platform));
+        });
+      });
+    });
+  </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <script>hljs.highlightAll();</script>
+  <script>
+    document.querySelectorAll('.menu-toggle').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const links = btn.parentElement.querySelector('.header-links');
+        const isOpen = links.classList.toggle('open');
+        btn.setAttribute('aria-expanded', isOpen);
+      });
+    });
+  </script>
+  <script src="../../js/copy.js" defer></script>
+</body>
+</html>

--- a/en/mp/index.html
+++ b/en/mp/index.html
@@ -91,6 +91,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p>Run the following command in the <code>mp-sample-js</code> folder to start a web server.</p>
             <pre><code class="language-bash">python3 -m http.server 8000</code></pre>
             <p>You can run the sample program by accessing <code>http://localhost:8000/mpavatar</code> in your web browser. A port number other than 8000 can also be used.</p>
+            <p>If you want to try it without cloning, you can check how it works in your browser on the published sample site.</p>
+            <a href="https://mp.ailia.ai/mpavatar/" target="_blank" class="card-link">Sample site</a>
           </div>
         </div>
       </div>

--- a/en/sdk/index.html
+++ b/en/sdk/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../voice/">Voice</a>
         <a href="../tokenizer/">Tokenizer</a>
         <a href="../tracker/">Tracker</a>
+        <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
         <a href="../../sdk/" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>

--- a/en/setup/cuda/index.html
+++ b/en/setup/cuda/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../../voice/">Voice</a>
         <a href="../../tokenizer/">Tokenizer</a>
         <a href="../../tracker/">Tracker</a>
+        <a href="../../js/">JS</a>
+        <a href="../../mp/">MP</a>
         <a href="../../../setup/cuda/" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>

--- a/en/setup/python/index.html
+++ b/en/setup/python/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../../voice/">Voice</a>
         <a href="../../tokenizer/">Tokenizer</a>
         <a href="../../tracker/">Tracker</a>
+        <a href="../../js/">JS</a>
+        <a href="../../mp/">MP</a>
         <a href="../../../setup/python/" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>

--- a/en/setup/python/linux.html
+++ b/en/setup/python/linux.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../../voice/">Voice</a>
         <a href="../../tokenizer/">Tokenizer</a>
         <a href="../../tracker/">Tracker</a>
+        <a href="../../js/">JS</a>
+        <a href="../../mp/">MP</a>
         <a href="../../../setup/python/linux.html" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>

--- a/en/setup/python/mac.html
+++ b/en/setup/python/mac.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../../voice/">Voice</a>
         <a href="../../tokenizer/">Tokenizer</a>
         <a href="../../tracker/">Tracker</a>
+        <a href="../../js/">JS</a>
+        <a href="../../mp/">MP</a>
         <a href="../../../setup/python/mac.html" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>

--- a/en/setup/python/windows.html
+++ b/en/setup/python/windows.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../../voice/">Voice</a>
         <a href="../../tokenizer/">Tokenizer</a>
         <a href="../../tracker/">Tracker</a>
+        <a href="../../js/">JS</a>
+        <a href="../../mp/">MP</a>
         <a href="../../../setup/python/windows.html" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>

--- a/en/setup/qnn/index.html
+++ b/en/setup/qnn/index.html
@@ -61,6 +61,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../../voice/">Voice</a>
         <a href="../../tokenizer/">Tokenizer</a>
         <a href="../../tracker/">Tracker</a>
+        <a href="../../js/">JS</a>
+        <a href="../../mp/">MP</a>
         <a href="../../../setup/qnn/" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>

--- a/en/setup/vulkan/index.html
+++ b/en/setup/vulkan/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../../voice/">Voice</a>
         <a href="../../tokenizer/">Tokenizer</a>
         <a href="../../tracker/">Tracker</a>
+        <a href="../../js/">JS</a>
+        <a href="../../mp/">MP</a>
         <a href="../../../setup/vulkan/" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>

--- a/en/setup/woa/index.html
+++ b/en/setup/woa/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../../voice/">Voice</a>
         <a href="../../tokenizer/">Tokenizer</a>
         <a href="../../tracker/">Tracker</a>
+        <a href="../../js/">JS</a>
+        <a href="../../mp/">MP</a>
         <a href="../../../setup/woa/" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>

--- a/en/speech/index.html
+++ b/en/speech/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../voice/">Voice</a>
         <a href="../tokenizer/">Tokenizer</a>
         <a href="../tracker/">Tracker</a>
+        <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
         <a href="../../speech/" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>

--- a/en/tflite/index.html
+++ b/en/tflite/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../voice/">Voice</a>
         <a href="../tokenizer/">Tokenizer</a>
         <a href="../tracker/">Tracker</a>
+        <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
         <a href="../../tflite/" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>

--- a/en/tokenizer/index.html
+++ b/en/tokenizer/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../voice/">Voice</a>
         <a href="../tokenizer/">Tokenizer</a>
         <a href="../tracker/">Tracker</a>
+        <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
         <a href="../../tokenizer/" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>

--- a/en/tracker/index.html
+++ b/en/tracker/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../voice/">Voice</a>
         <a href="../tokenizer/">Tokenizer</a>
         <a href="../tracker/">Tracker</a>
+        <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
         <a href="../../tracker/" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>

--- a/en/voice/index.html
+++ b/en/voice/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../voice/">Voice</a>
         <a href="../tokenizer/">Tokenizer</a>
         <a href="../tracker/">Tracker</a>
+        <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
         <a href="../../voice/" hreflang="ja" lang="ja">JA</a>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     .card-icon.llm       { background: #f3e8ff; color: #7c3aed; }
     .card-icon.tracker   { background: #e0f2fe; color: #0284c7; }
     .card-icon.tflite    { background: #fff7ed; color: #ea580c; }
+    .card-icon.mp        { background: #ffe4e6; color: #e11d48; }
     .card h3 { margin-bottom: 8px; }
     .card p { font-size: 14px; color: var(--text-light); flex: 1; margin-bottom: 16px; }
     .card-platforms { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 16px; }
@@ -92,6 +93,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="tokenizer/">Tokenizer</a>
         <a href="tracker/">Tracker</a>
         <a href="js/">JS</a>
+        <a href="mp/">MP</a>
         <a href="en/" hreflang="en" lang="en">EN</a>
       </div>
     </div>
@@ -248,6 +250,19 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <span class="platform-tag">WebAssembly</span>
         </div>
         <a href="js/" class="card-link">ドキュメントを見る</a>
+      </div>
+
+      <div class="card">
+        <div class="card-icon mp">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+        </div>
+        <h3>ailia MotionPortrait</h3>
+        <p>1 枚の画像から表情・リップシンクアニメーションを生成するアバターライブラリ。</p>
+        <div class="card-platforms">
+          <span class="platform-tag">JavaScript</span>
+          <span class="platform-tag">Unity</span>
+        </div>
+        <a href="mp/" class="card-link">ドキュメントを見る</a>
       </div>
 
     </div>

--- a/js/index.html
+++ b/js/index.html
@@ -52,6 +52,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../tokenizer/">Tokenizer</a>
         <a href="../tracker/">Tracker</a>
         <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
         <a href="../en/js/" hreflang="en" lang="en">EN</a>
       </div>
     </div>

--- a/llm/index.html
+++ b/llm/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../voice/">Voice</a>
         <a href="../tokenizer/">Tokenizer</a>
         <a href="../tracker/">Tracker</a>
+        <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
         <a href="../en/llm/" hreflang="en" lang="en">EN</a>
       </div>
     </div>

--- a/mp/index.html
+++ b/mp/index.html
@@ -91,6 +91,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p><code>mp-sample-js</code> フォルダで下記のコマンドを実行して、Web サーバーを立ち上げます。</p>
             <pre><code class="language-bash">python3 -m http.server 8000</code></pre>
             <p>Web ブラウザで <code>http://localhost:8000/mpavatar</code> にアクセスすることで、サンプルプログラムを実行可能です。ポート番号には 8000 番以外も指定可能です。</p>
+            <p>クローン不要で試したい場合は、公開中のサンプルサイトからブラウザだけで動作を確認できます。</p>
+            <a href="https://mp.ailia.ai/mpavatar/" target="_blank" class="card-link">サンプルサイト</a>
           </div>
         </div>
       </div>

--- a/mp/index.html
+++ b/mp/index.html
@@ -1,0 +1,354 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5Q579RMM');</script>
+<!-- End Google Tag Manager -->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ailia MotionPortrait - ドキュメント</title>
+  <meta name="description" content="ailia MotionPortrait - 1 枚の画像から表情・リップシンクアニメーションを生成するアバターライブラリ。">
+  <link rel="canonical" href="https://docs.ailia.ai/mp/">
+  <link rel="alternate" hreflang="en" href="https://docs.ailia.ai/en/mp/">
+  <link rel="alternate" hreflang="ja" href="https://docs.ailia.ai/mp/">
+  <link rel="alternate" hreflang="x-default" href="https://docs.ailia.ai/en/mp/">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="ja_JP">
+  <meta property="og:locale:alternate" content="en_US">
+  <meta property="og:site_name" content="ailia Documentation">
+  <meta property="og:url" content="https://docs.ailia.ai/mp/">
+  <meta property="og:title" content="ailia MotionPortrait - ドキュメント">
+  <meta property="og:description" content="ailia MotionPortrait - 1 枚の画像から表情・リップシンクアニメーションを生成するアバターライブラリ。">
+  <meta property="og:image" content="https://docs.ailia.ai/ailia_logo.png">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="ailia MotionPortrait - ドキュメント">
+  <meta name="twitter:description" content="ailia MotionPortrait - 1 枚の画像から表情・リップシンクアニメーションを生成するアバターライブラリ。">
+  <meta name="twitter:image" content="https://docs.ailia.ai/ailia_logo.png">
+  <link rel="icon" type="image/png" href="../favicon.png">
+  <link rel="stylesheet" href="../css/common.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+</head>
+<body>
+  <header>
+    <div class="header-inner">
+      <div class="logo">
+        <a href="https://docs.ailia.ai/" class="logo-icon"><img src="../ailia_logo.png" alt="ailia"></a>
+        <a href="./" class="logo-text">ailia MotionPortrait Docs</a>
+      </div>
+      <button class="menu-toggle" aria-label="メニューを開く" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+      </button>
+      <div class="header-links">
+        <a href="../">Top</a>
+        <a href="../sdk/">SDK</a>
+        <a href="../tflite/">TFLite</a>
+        <a href="../llm/">LLM</a>
+        <a href="../speech/">Speech</a>
+        <a href="../voice/">Voice</a>
+        <a href="../tokenizer/">Tokenizer</a>
+        <a href="../tracker/">Tracker</a>
+        <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
+        <a href="../en/mp/" hreflang="en" lang="en">EN</a>
+      </div>
+    </div>
+  </header>
+
+  <section class="hero">
+    <h1>ailia MotionPortrait</h1>
+    <p>プリセットのアバターを試したり、好きな画像をドラッグ&amp;ドロップして自分だけのアバターを生成し、表情・リップシンクアニメーションを再生できるライブラリです。</p>
+  </section>
+
+  <!-- Getting Started -->
+  <section class="getting-started-section">
+    <div class="section">
+      <h2 class="section-title">はじめに</h2>
+      <p class="section-subtitle">プラットフォームを選び、最初のアニメーション生成を実行してみましょう。</p>
+
+      <div class="platform-tabs" role="tablist">
+        <button class="platform-tab active" data-platform="javascript" role="tab">JavaScript</button>
+        <button class="platform-tab" data-platform="unity" role="tab">Unity</button>
+      </div>
+
+      <!-- JavaScript -->
+      <div class="platform-panel" data-platform="javascript">
+        <div class="steps-grid">
+          <div class="step">
+            <div class="step-number">1</div>
+            <h3>インストール</h3>
+            <p>サンプルプログラム <code>mp-sample-js</code> をクローンしてください。SDK <code>mp-sdk-js</code> は <code>mp-sample-js</code> プロジェクト内に submodule として含まれています。</p>
+            <a href="https://github.com/ailia-ai/mp-sample-js" target="_blank" class="card-link">サンプルプログラム</a>
+            <a href="https://github.com/ailia-ai/mp-sdk-js" target="_blank" class="card-link">SDK</a>
+          </div>
+          <div class="step">
+            <div class="step-number">2</div>
+            <h3>実行</h3>
+            <p><code>mp-sample-js</code> フォルダで下記のコマンドを実行して、Web サーバーを立ち上げます。</p>
+            <pre><code class="language-bash">python3 -m http.server 8000</code></pre>
+            <p>Web ブラウザで <code>http://localhost:8000/mpavatar</code> にアクセスすることで、サンプルプログラムを実行可能です。ポート番号には 8000 番以外も指定可能です。</p>
+            <p>Python や git をまだインストールしていない方は、<a href="../setup/python/">Python 環境のセットアップ（Windows / Mac / Linux）</a> を先にご覧ください。</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Unity -->
+      <div class="platform-panel hidden" data-platform="unity">
+        <div class="steps-grid">
+          <div class="step">
+            <div class="step-number">1</div>
+            <h3>インストール</h3>
+            <p>サンプルプログラム <code>mp-sample-unity</code> をクローンした後、Unity 6.3 LTS (6000.3.16f1) 以降で開きます。SDK <code>mp-sdk-unity</code> は Package Manager 経由で自動的にダウンロードされます。</p>
+            <a href="https://github.com/ailia-ai/mp-sample-unity" target="_blank" class="card-link">サンプルプログラム</a>
+            <a href="https://github.com/ailia-ai/mp-sdk-unity" target="_blank" class="card-link">SDK</a>
+          </div>
+          <div class="step">
+            <div class="step-number">2</div>
+            <h3>実行</h3>
+            <p><code>mpSampleScene.unity</code> のシーンを開き、Play してください。または、メニューバーの [File]-[Build Profiles] からビルドして実行してください。</p>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- System Requirements -->
+  <section class="section">
+    <h2 class="section-title">動作環境</h2>
+    <p class="section-subtitle">ailia MotionPortrait はブラウザおよびモバイル環境で動作します。</p>
+    <div class="req-grid">
+      <div class="platform-panel" data-platform="javascript">
+        <div class="req-card">
+          <h3>JavaScript</h3>
+          <ul>
+            <li>WebGL 対応の Web ブラウザ</li>
+            <li>HTTP サーバ経由での実行</li>
+            <li>インターネット接続のある環境</li>
+          </ul>
+        </div>
+      </div>
+      <div class="platform-panel hidden" data-platform="unity">
+        <div class="req-card">
+          <h3>Unity</h3>
+          <ul>
+            <li>Windows 10 (バージョン 21H1 以降) / Windows 11</li>
+            <li>macOS Monterey (12.0) 以降</li>
+            <li>Linux (Ubuntu 22.04 / 24.04)</li>
+            <li>iOS 15 以上</li>
+            <li>Android 7.1 (API 25) 以上</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+<!--
+  <section class="getting-started-section">
+    <div class="section">
+      <h2 class="section-title">機能</h2>
+      <p class="section-subtitle">JavaScript 版サンプルプログラムで確認できる機能。</p>
+      <div class="req-grid">
+        <div class="req-card">
+          <h3>アバター生成</h3>
+          <ul>
+            <li>用意されたアバターへの切り替え（デフォルト 6 種類）</li>
+            <li>任意の画像ファイルからアバターを生成</li>
+          </ul>
+        </div>
+        <div class="req-card">
+          <h3>アクセサリー</h3>
+          <ul>
+            <li>髪型（5 種類）/ メガネ（5 種類）</li>
+            <li>ヒゲ（4 種類）/ コンタクトレンズ（3 種類）</li>
+            <li>CHANGE で切り替え、CLEAR で解除</li>
+          </ul>
+        </div>
+        <div class="req-card">
+          <h3>メイク</h3>
+          <ul>
+            <li>口紅（5 種類）/ チーク（6 種類）/ アイメイク（6 種類）</li>
+            <li>CLEAR で全てのメイクを解除</li>
+          </ul>
+        </div>
+        <div class="req-card">
+          <h3>アニメーション / 表情</h3>
+          <ul>
+            <li>ANIMATION — 2 種類のアニメーションを再生（あらかじめ用意されているアバターのみ対応）</li>
+            <li>SPEECH — 2 種類の音声でリップシンク</li>
+            <li>EXPRESSION — 7 種類の表情に切り替え</li>
+            <li>マウス方向への視線追従、FPS 表示</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+-->
+
+<!--
+  <section class="getting-started-section">
+    <div class="section">
+      <h2 class="section-title">プロジェクトで API を使う</h2>
+      <p class="section-subtitle">自分のアプリケーションにアバターを組み込む最小サンプル。アバターファイル（<code>.bin</code>）は <code>js/mp_fileio.js</code> 内のファイルリストに追加して読み込みます。</p>
+      <pre class="code-block"><code class="language-javascript">// 音声ファイルを指定してリップシンクを開始/停止
+var voiceId = mpwebgl.instance.loadvoice('items/voice/voice0.mp3');
+if (mpwebgl.instance.isanimplaying(2)) {
+    mpwebgl.instance.pauseaudio();
+    mpwebgl.instance.unloadanimation();
+    mpwebgl.instance.destroyvoice();
+}</code></pre>
+    </div>
+  </section>
+-->
+
+<!--
+  <section class="section">
+    <h2 class="section-title">プラットフォーム別 API リファレンス</h2>
+    <div class="card-grid">
+      <div class="card">
+        <h3>JavaScript</h3>
+        <ul>
+          <li><a href="#">API リファレンス（URL未設定）</a></li>
+          <li><a href="#">サンプルリポジトリ（URL未設定）</a></li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>Unity</h3>
+        <ul>
+          <li>準備中</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+-->
+
+<!--
+  <section class="getting-started-section">
+    <div class="section">
+      <h2 class="section-title">よくある質問</h2>
+      <p class="section-subtitle">ailia MotionPortrait についてのよくある質問。</p>
+      <div class="faq-list">
+
+        <details class="faq-item">
+          <summary>対応ブラウザ・動作環境は?</summary>
+          <p>WebGL に対応したモダンブラウザ（Chrome、Edge、Safari など）で動作します。詳細な動作要件は準備中です。</p>
+        </details>
+
+        <details class="faq-item">
+          <summary>自分の画像をアバターとして使うには?</summary>
+          <p>GUI の「BROWSE FILE」ボタンから画像ファイルを選択すると、その画像をもとにアバターが生成されます。あらかじめ用意されたアバターと同様に、Hair / Glasses / Beard / Lens やメイクを付加できます。より精密な特徴点調整が必要な場合は、専用のアバター生成ツール（要アカウント）を使用します。画像は正方形（512×512 / 1024×1024 / 2048×2048 のいずれか）を使用してください。</p>
+        </details>
+
+        <details class="faq-item">
+          <summary>サンプルで使用しているモデルファイルはどこにありますか?</summary>
+          <p>アバターの <code>.bin</code> ファイルは <code>items/face</code> フォルダに配置し、<code>js/mp_fileio.js</code> のファイルリストに追加します。</p>
+        </details>
+
+        <details class="faq-item">
+          <summary>画像のアルファチャンネルはどう扱われますか?</summary>
+          <p>PNG 画像にアルファチャンネルがある場合、その値がキャラクターの輪郭として使用されます。背景が完全に不透明（アルファ値 255）な画像を使うと、輪郭が四角形になります。JPEG など、アルファチャンネルを持たない形式を使うと、輪郭は自動推定されます。より高精度なアバターを作成する場合は、アルファチャンネルにキャラクターのマスク値を含めてください。</p>
+        </details>
+
+        <details class="faq-item">
+          <summary>アバターの解像度はどう指定しますか?</summary>
+          <p><code>texsize</code> オプションでアバターの解像度を指定できます。512 / 1024 / 2048 (px) から選択可能です。</p>
+        </details>
+
+        <details class="faq-item">
+          <summary>インストール方法はどこに記載されていますか?</summary>
+          <p>インストール手順はこのページの「はじめに」に記載しています。ボタンごとの詳しい操作方法については「資料」の操作マニュアル（PDF）をご参照ください。</p>
+        </details>
+
+      </div>
+    </div>
+  </section>
+-->
+
+  <section class="materials-section">
+    <div class="section">
+      <h2 class="section-title">資料</h2>
+      <div class="materials-grid">
+        <div class="platform-panel" data-platform="javascript">
+          <a href="docs/mp_animator_js_manual_ja.pdf" target="_blank" class="material-item">
+            <div class="material-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>
+            </div>
+            <div class="material-text">
+              JavaScript版 操作マニュアル (PDF)
+              <small>サンプルプログラム操作マニュアル Ver. 1.0</small>
+            </div>
+          </a>
+        </div>
+        <div class="platform-panel hidden" data-platform="unity">
+          <a href="docs/mp_animator_unity_manual_ja.pdf" target="_blank" class="material-item">
+            <div class="material-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>
+            </div>
+            <div class="material-text">
+              Unity版 操作マニュアル (PDF)
+              <small>サンプルプログラム操作マニュアル Ver. 1.0</small>
+            </div>
+          </a>
+        </div>
+        <a href="https://ailia.ai/mp/" target="_blank" class="material-item">
+          <div class="material-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>
+          </div>
+          <div class="material-text">
+            Product Site
+            <small>ailia.ai/mp/</small>
+          </div>
+        </a>
+      </div>
+    </div>
+  </section>
+
+<!-- Related Articles -->
+<section class="section">
+  <h2 class="section-title">関連記事</h2>
+  <p class="section-subtitle">ailia Tech Blog のモデル解説・リリースノート・チュートリアルです。</p>
+  <div class="articles-grid">
+    <a class="article-card" href="https://tech.ailia.ai/motionportrait-llm%E3%81%A8%E5%90%88%E3%82%8F%E3%81%9B%E3%81%A6%E4%BD%BF%E3%81%88%E3%82%8Bax%E3%81%AE%E3%82%A2%E3%83%90%E3%82%BF%E3%83%BC%E3%82%BD%E3%83%AA%E3%83%A5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3-ea5d940ead03/" target="_blank" rel="noopener">
+      <div class="article-title">MotionPortrait: LLMと合わせて使えるaxのアバターソリューション</div>
+      <div class="article-source">tech.ailia.ai</div>
+    </a>
+  </div>
+</section>
+<!-- /Related Articles -->
+
+  <footer>
+    <p><a href="https://ailia.ai/" target="_blank">ailia Inc.</a></p>
+    <p class="footer-copy">&copy; ailia Inc. All rights reserved.</p>
+  </footer>
+
+  <script>
+    document.querySelectorAll('.platform-tabs').forEach(tabsBar => {
+      const tabs = tabsBar.querySelectorAll('.platform-tab');
+      tabs.forEach(tab => {
+        tab.addEventListener('click', () => {
+          const platform = tab.dataset.platform;
+          tabs.forEach(t => t.classList.toggle('active', t === tab));
+          // This page has a single tab bar, but its panels live in several
+          // sections, so every panel on the page follows the selected tab.
+          document.querySelectorAll('.platform-panel').forEach(p => p.classList.toggle('hidden', p.dataset.platform !== platform));
+        });
+      });
+    });
+  </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <script>hljs.highlightAll();</script>
+  <script>
+    document.querySelectorAll('.menu-toggle').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const links = btn.parentElement.querySelector('.header-links');
+        const isOpen = links.classList.toggle('open');
+        btn.setAttribute('aria-expanded', isOpen);
+      });
+    });
+  </script>
+  <script src="../js/copy.js" defer></script>
+</body>
+</html>

--- a/mp/index.html
+++ b/mp/index.html
@@ -272,7 +272,7 @@ if (mpwebgl.instance.isanimplaying(2)) {
       <h2 class="section-title">資料</h2>
       <div class="materials-grid">
         <div class="platform-panel" data-platform="javascript">
-          <a href="docs/mp_animator_js_manual_ja.pdf" target="_blank" class="material-item">
+          <a href="https://ailia.ai/mp/docs/mp_animator_js_manual_ja.pdf" target="_blank" class="material-item">
             <div class="material-icon">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>
             </div>
@@ -283,7 +283,7 @@ if (mpwebgl.instance.isanimplaying(2)) {
           </a>
         </div>
         <div class="platform-panel hidden" data-platform="unity">
-          <a href="docs/mp_animator_unity_manual_ja.pdf" target="_blank" class="material-item">
+          <a href="https://ailia.ai/mp/docs/mp_animator_unity_manual_ja.pdf" target="_blank" class="material-item">
             <div class="material-icon">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>
             </div>

--- a/mp/index.html
+++ b/mp/index.html
@@ -121,17 +121,18 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <div class="step">
             <div class="step-number">1</div>
             <h3>インストール</h3>
-            <p>サンプルプログラム <code>mp-sample-kotlin</code> をクローンしてサブモジュールを初期化し、Android Studio で開きます。SDK <code>mp-sdk-kotlin</code> は <code>mp-sample-kotlin</code> プロジェクト内に submodule として含まれています。</p>
+            <p>サンプルプログラム <code>mp-sample-kotlin</code> をクローンしてサブモジュールを初期化してください。SDK <code>mp-sdk-kotlin</code> は <code>mp-sample-kotlin</code> プロジェクト内に submodule として含まれています。</p>
             <pre><code class="language-bash">git clone https://github.com/ailia-ai/mp-sample-kotlin.git
 cd mp-sample-kotlin
 git submodule update --init --recursive</code></pre>
             <a href="https://github.com/ailia-ai/mp-sample-kotlin" target="_blank" class="card-link">サンプルプログラム</a>
             <a href="https://github.com/ailia-ai/mp-sdk-kotlin" target="_blank" class="card-link">SDK</a>
+            <a href="https://github.com/ailia-ai/mp-sample-kotlin/blob/main/TUTORIAL.md" target="_blank" class="card-link">チュートリアル</a>
           </div>
           <div class="step">
             <div class="step-number">2</div>
             <h3>実行</h3>
-            <p>Android 端末を USB で接続するか、エミュレータを起動し、Android Studio の Run ボタンからサンプルプログラムを実行してください。</p>
+            <p>Android Studio Narwhal 3 Feature Drop (2025.1.3) 以降で <code>mp-sample-kotlin</code> を開き、Android 端末を USB で接続して、Run ボタンからビルド・インストール・実行してください。</p>
           </div>
         </div>
       </div>
@@ -170,8 +171,8 @@ git submodule update --init --recursive</code></pre>
         <div class="req-card">
           <h3>Kotlin</h3>
           <ul>
-            <li>Android 7.1 (API 25) 以上</li>
-            <li>Android Studio 2025.1.3 以降</li>
+            <li>Android 7.0 (API 24) 以上</li>
+            <li>Android Studio Narwhal 3 Feature Drop (2025.1.3) 以降</li>
             <li>Kotlin / Java (JNI)</li>
           </ul>
         </div>
@@ -322,6 +323,17 @@ if (mpwebgl.instance.isanimplaying(2)) {
             </div>
             <div class="material-text">
               Unity版 操作マニュアル (PDF)
+              <small>サンプルプログラム操作マニュアル Ver. 1.0</small>
+            </div>
+          </a>
+        </div>
+        <div class="platform-panel hidden" data-platform="kotlin">
+          <a href="https://ailia.ai/mp/docs/mp_animator_kotlin_manual_ja.pdf" target="_blank" class="material-item">
+            <div class="material-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>
+            </div>
+            <div class="material-text">
+              Kotlin版 操作マニュアル (PDF)
               <small>サンプルプログラム操作マニュアル Ver. 1.0</small>
             </div>
           </a>

--- a/sdk/index.html
+++ b/sdk/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../voice/">Voice</a>
         <a href="../tokenizer/">Tokenizer</a>
         <a href="../tracker/">Tracker</a>
+        <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
         <a href="../en/sdk/" hreflang="en" lang="en">EN</a>
       </div>
     </div>

--- a/setup/cuda/index.html
+++ b/setup/cuda/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../../voice/">Voice</a>
         <a href="../../tokenizer/">Tokenizer</a>
         <a href="../../tracker/">Tracker</a>
+        <a href="../../js/">JS</a>
+        <a href="../../mp/">MP</a>
         <a href="../../en/setup/cuda/" hreflang="en" lang="en">EN</a>
       </div>
     </div>

--- a/setup/python/index.html
+++ b/setup/python/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../../voice/">Voice</a>
         <a href="../../tokenizer/">Tokenizer</a>
         <a href="../../tracker/">Tracker</a>
+        <a href="../../js/">JS</a>
+        <a href="../../mp/">MP</a>
         <a href="../../en/setup/python/" hreflang="en" lang="en">EN</a>
       </div>
     </div>

--- a/setup/python/linux.html
+++ b/setup/python/linux.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../../voice/">Voice</a>
         <a href="../../tokenizer/">Tokenizer</a>
         <a href="../../tracker/">Tracker</a>
+        <a href="../../js/">JS</a>
+        <a href="../../mp/">MP</a>
         <a href="../../en/setup/python/linux.html" hreflang="en" lang="en">EN</a>
       </div>
     </div>

--- a/setup/python/mac.html
+++ b/setup/python/mac.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../../voice/">Voice</a>
         <a href="../../tokenizer/">Tokenizer</a>
         <a href="../../tracker/">Tracker</a>
+        <a href="../../js/">JS</a>
+        <a href="../../mp/">MP</a>
         <a href="../../en/setup/python/mac.html" hreflang="en" lang="en">EN</a>
       </div>
     </div>

--- a/setup/python/windows.html
+++ b/setup/python/windows.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../../voice/">Voice</a>
         <a href="../../tokenizer/">Tokenizer</a>
         <a href="../../tracker/">Tracker</a>
+        <a href="../../js/">JS</a>
+        <a href="../../mp/">MP</a>
         <a href="../../en/setup/python/windows.html" hreflang="en" lang="en">EN</a>
       </div>
     </div>

--- a/setup/qnn/index.html
+++ b/setup/qnn/index.html
@@ -61,6 +61,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../../voice/">Voice</a>
         <a href="../../tokenizer/">Tokenizer</a>
         <a href="../../tracker/">Tracker</a>
+        <a href="../../js/">JS</a>
+        <a href="../../mp/">MP</a>
         <a href="../../en/setup/qnn/" hreflang="en" lang="en">EN</a>
       </div>
     </div>

--- a/setup/vulkan/index.html
+++ b/setup/vulkan/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../../voice/">Voice</a>
         <a href="../../tokenizer/">Tokenizer</a>
         <a href="../../tracker/">Tracker</a>
+        <a href="../../js/">JS</a>
+        <a href="../../mp/">MP</a>
         <a href="../../en/setup/vulkan/" hreflang="en" lang="en">EN</a>
       </div>
     </div>

--- a/setup/woa/index.html
+++ b/setup/woa/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../../voice/">Voice</a>
         <a href="../../tokenizer/">Tokenizer</a>
         <a href="../../tracker/">Tracker</a>
+        <a href="../../js/">JS</a>
+        <a href="../../mp/">MP</a>
         <a href="../../en/setup/woa/" hreflang="en" lang="en">EN</a>
       </div>
     </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -50,6 +50,22 @@
     <xhtml:link rel="alternate" hreflang="en" href="https://docs.ailia.ai/en/js/"/>
   </url>
   <url>
+    <loc>https://docs.ailia.ai/mp/</loc>
+    <lastmod>2026-07-27</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://docs.ailia.ai/mp/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://docs.ailia.ai/en/mp/"/>
+  </url>
+  <url>
+    <loc>https://docs.ailia.ai/en/mp/</loc>
+    <lastmod>2026-07-27</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://docs.ailia.ai/mp/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://docs.ailia.ai/en/mp/"/>
+  </url>
+  <url>
     <loc>https://docs.ailia.ai/tflite/</loc>
     <lastmod>2026-05-02</lastmod>
     <changefreq>weekly</changefreq>

--- a/speech/index.html
+++ b/speech/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../voice/">Voice</a>
         <a href="../tokenizer/">Tokenizer</a>
         <a href="../tracker/">Tracker</a>
+        <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
         <a href="../en/speech/" hreflang="en" lang="en">EN</a>
       </div>
     </div>

--- a/tflite/index.html
+++ b/tflite/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../voice/">Voice</a>
         <a href="../tokenizer/">Tokenizer</a>
         <a href="../tracker/">Tracker</a>
+        <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
         <a href="../en/tflite/" hreflang="en" lang="en">EN</a>
       </div>
     </div>

--- a/tokenizer/index.html
+++ b/tokenizer/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../voice/">Voice</a>
         <a href="../tokenizer/">Tokenizer</a>
         <a href="../tracker/">Tracker</a>
+        <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
         <a href="../en/tokenizer/" hreflang="en" lang="en">EN</a>
       </div>
     </div>

--- a/tracker/index.html
+++ b/tracker/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../voice/">Voice</a>
         <a href="../tokenizer/">Tokenizer</a>
         <a href="../tracker/">Tracker</a>
+        <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
         <a href="../en/tracker/" hreflang="en" lang="en">EN</a>
       </div>
     </div>

--- a/voice/index.html
+++ b/voice/index.html
@@ -51,6 +51,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <a href="../voice/">Voice</a>
         <a href="../tokenizer/">Tokenizer</a>
         <a href="../tracker/">Tracker</a>
+        <a href="../js/">JS</a>
+        <a href="../mp/">MP</a>
         <a href="../en/voice/" hreflang="en" lang="en">EN</a>
       </div>
     </div>


### PR DESCRIPTION
Restructure the MotionPortrait page to match the other library pages:

- Move the English page from mp/index_en.html to en/mp/index.html
- Drop mp/style/style.css and mp/img/ in favour of the shared css/common.css, ailia_logo.png and favicon.png
- Replace the inlined copy-button script with the shared js/copy.js
- Add the GTM snippet, canonical / hreflang / OGP / Twitter metadata and the common header and footer markup
- Add the ailia MotionPortrait card to both top pages and register /mp/ and /en/mp/ in the sitemap
- Add JS and MP links to the header of every page