### PR TITLE
Add clone commands to MP JavaScript Getting Started and unify Kotlin description.

### DIFF
--- a/en/mp/index.html
+++ b/en/mp/index.html
@@ -82,6 +82,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <div class="step-number">1</div>
             <h3>Install</h3>
             <p>Clone the sample program <code>mp-sample-js</code>. The SDK <code>mp-sdk-js</code> is included as a submodule within the <code>mp-sample-js</code> project.</p>
+            <pre><code class="language-bash">git clone https://github.com/ailia-ai/mp-sample-js.git
+cd mp-sample-js
+git submodule update --init --recursive</code></pre>
             <a href="https://github.com/ailia-ai/mp-sample-js" target="_blank" class="card-link">Sample Repository</a>
             <a href="https://github.com/ailia-ai/mp-sdk-js" target="_blank" class="card-link">SDK</a>
           </div>
@@ -121,7 +124,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <div class="step">
             <div class="step-number">1</div>
             <h3>Install</h3>
-            <p>Clone the sample program <code>mp-sample-kotlin</code> and initialize its submodules. The SDK <code>mp-sdk-kotlin</code> is included as a submodule within the <code>mp-sample-kotlin</code> project.</p>
+            <p>Clone the sample program <code>mp-sample-kotlin</code>. The SDK <code>mp-sdk-kotlin</code> is included as a submodule within the <code>mp-sample-kotlin</code> project.</p>
             <pre><code class="language-bash">git clone https://github.com/ailia-ai/mp-sample-kotlin.git
 cd mp-sample-kotlin
 git submodule update --init --recursive</code></pre>

--- a/mp/index.html
+++ b/mp/index.html
@@ -82,6 +82,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <div class="step-number">1</div>
             <h3>インストール</h3>
             <p>サンプルプログラム <code>mp-sample-js</code> をクローンしてください。SDK <code>mp-sdk-js</code> は <code>mp-sample-js</code> プロジェクト内に submodule として含まれています。</p>
+            <pre><code class="language-bash">git clone https://github.com/ailia-ai/mp-sample-js.git
+cd mp-sample-js
+git submodule update --init --recursive</code></pre>
             <a href="https://github.com/ailia-ai/mp-sample-js" target="_blank" class="card-link">サンプルプログラム</a>
             <a href="https://github.com/ailia-ai/mp-sdk-js" target="_blank" class="card-link">SDK</a>
           </div>
@@ -121,7 +124,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           <div class="step">
             <div class="step-number">1</div>
             <h3>インストール</h3>
-            <p>サンプルプログラム <code>mp-sample-kotlin</code> をクローンしてサブモジュールを初期化してください。SDK <code>mp-sdk-kotlin</code> は <code>mp-sample-kotlin</code> プロジェクト内に submodule として含まれています。</p>
+            <p>サンプルプログラム <code>mp-sample-kotlin</code> をクローンしてください。SDK <code>mp-sdk-kotlin</code> は <code>mp-sample-kotlin</code> プロジェクト内に submodule として含まれています。</p>
             <pre><code class="language-bash">git clone https://github.com/ailia-ai/mp-sample-kotlin.git
 cd mp-sample-kotlin
 git submodule update --init --recursive</code></pre>


### PR DESCRIPTION
## 概要
MP の Getting Started ページ(日英)を更新し、JavaScript のインストール手順を Kotlin と同様の形式に揃えました。

## 変更内容
- **JavaScript の Install 手順にコマンドブロックを追加**
  `git clone` からサブモジュール初期化までのコマンドを記載し、コピー&ペーストで実行できるようにしました。
  - `git clone https://github.com/ailia-ai/mp-sample-js.git`
  - `cd mp-sample-js`
  - `git submodule update --init --recursive`
- **Kotlin の説明文を統一**
  「クローンしてサブモジュールを初期化してください」→「クローンしてください」に変更し、JavaScript 側の説明文と表現を揃えました。

## 対象ファイル
- `mp/index.html`(日本語版)
- `en/mp/index.html`(英語版)